### PR TITLE
Add more Wave 2 sensors

### DIFF
--- a/custom_components/ecoflow_cloud/devices/const.py
+++ b/custom_components/ecoflow_cloud/devices/const.py
@@ -110,6 +110,29 @@ POWER_SUB_MODE_OPTIONS = {
     "Manual": 3
 }
 
+TEMP_SYS_OPTIONS = {
+    "Celsius": 0,
+    "Fahrenheit": 1,
+}
+
+TEMP_DISPLAY_OPTIONS = {
+    "Ambient": 0,
+    "Outlet": 1,
+}
+
+RGB_STATE_OPTIONS = {
+    "Follow Screen": 0,
+    "Always On": 1,
+    "Always Off": 2,
+}
+
+AUTO_DRAIN_OPTIONS = {
+    "Manual Drainage On": 0,
+    "No Drainage On": 1,
+    "Manual Drainage Off": 2,
+    "No Drainage Off": 3,
+}
+
 POWER_SUPPLY_PRIORITY_OPTIONS = {
     "Prioritize power supply": 0,
     "Prioritize power storage": 1
@@ -230,6 +253,8 @@ DC_TIMEOUT = "DC (12V) Timeout"
 DC_CHARGE_CURRENT = "DC (12V) Charge Current"
 GEN_AUTO_START_LEVEL = "Generator Auto Start Level"
 GEN_AUTO_STOP_LEVEL = "Generator Auto Stop Level"
+TIMER_DURATION = "Timer"
+TIMER_ENABLED = "Timer Enabled"
 
 POWER = "Power"
 CURRENT = "Current"
@@ -276,6 +301,26 @@ FAN_MODE = "Wind speed"
 MAIN_MODE = "Main mode"
 REMOTE_MODE = "Remote startup/shutdown"
 POWER_SUB_MODE = "Sub-mode"
+TEMP_SYS = "Temperature Unit"
+TEMP_DISPLAY = "Temperature Display"
+RGB_STATE = "Light Strip"
+AUTO_DRAIN = "Automatic Drainage"
+
+# Wave 2 additional sensors
+PV_INPUT_POWER = "PV Input Power"
+PV_CHARGING_POWER = "PV Charging Power"
+PV_VOLTAGE = "PV Voltage"
+PV_CURRENT = "PV Current"
+BUS_VOLTAGE = "Bus Voltage"
+AC_FREQUENCY = "AC Input Frequency"
+AC_VOLT_RMS = "AC Voltage RMS"
+AC_CURR_RMS = "AC Current RMS"
+MPPT_WORK = "MPPT Mode"
+
+MPPT_WORK_OPTIONS = {
+    "Car Charging": 1,
+    "Solar Charging": 2,
+}
 
 # Smart Meter
 SMART_METER_POWER_GLOBAL = "Power Grid Global"

--- a/custom_components/ecoflow_cloud/devices/internal/wave2.py
+++ b/custom_components/ecoflow_cloud/devices/internal/wave2.py
@@ -1,12 +1,28 @@
-from homeassistant.components.switch import SwitchEntity
+from custom_components.ecoflow_cloud.switch import (
+    EnabledEntity,
+    InvertedBeeperEntity,
+    BaseSwitchEntity,
+)
 
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import const, BaseDevice
 from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSelectEntity
-from custom_components.ecoflow_cloud.number import SetTempEntity
-from custom_components.ecoflow_cloud.select import DictSelectEntity
-from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, RemainSensorEntity, TempSensorEntity, \
-    WattsSensorEntity, MilliCelsiusSensorEntity, CapacitySensorEntity, QuotaStatusSensorEntity
+from custom_components.ecoflow_cloud.number import SetTempEntity, ValueUpdateEntity
+from custom_components.ecoflow_cloud.select import DictSelectEntity, TimeoutDictSelectEntity
+from custom_components.ecoflow_cloud.sensor import (
+    LevelSensorEntity,
+    RemainSensorEntity,
+    TempSensorEntity,
+    WattsSensorEntity,
+    MilliCelsiusSensorEntity,
+    CapacitySensorEntity,
+    QuotaStatusSensorEntity,
+    CentivoltSensorEntity,
+    DecivoltSensorEntity,
+    DecihertzSensorEntity,
+    MilliampSensorEntity,
+    EnumSensorEntity,
+)
 
 
 class Wave2(BaseDevice):
@@ -37,22 +53,33 @@ class Wave2(BaseDevice):
             TempSensorEntity(client, self, "pd.coolTemp", "Air outlet temperature", False),
             TempSensorEntity(client, self, "pd.envTemp", "Ambient temperature", False),
 
+            LevelSensorEntity(client, self, "pd.batSoc", const.BATTERY_LEVEL_SOC),
+            CentivoltSensorEntity(client, self, "pd.batVolt", const.BATTERY_VOLT, False),
+            MilliampSensorEntity(client, self, "pd.batCurr", const.BATTERY_AMP, False),
+            CentivoltSensorEntity(client, self, "pd.mpptVol", const.PV_VOLTAGE, False),
+            MilliampSensorEntity(client, self, "pd.mpptCur", const.PV_CURRENT, False),
+            DecihertzSensorEntity(client, self, "pd.acFreq", const.AC_FREQUENCY),
+            DecivoltSensorEntity(client, self, "pd.acVoltRms", const.AC_VOLT_RMS),
+            MilliampSensorEntity(client, self, "pd.acCurrRms", const.AC_CURR_RMS),
+            DecivoltSensorEntity(client, self, "power.busVol", const.BUS_VOLTAGE),
+            EnumSensorEntity(client, self, "pd.mpptWork", const.MPPT_WORK, const.MPPT_WORK_OPTIONS),
+
             # power (pd)
-            WattsSensorEntity(client, self, "pd.mpptPwr", "PV input power"),
+            WattsSensorEntity(client, self, "pd.mpptPwr", const.PV_INPUT_POWER),
             WattsSensorEntity(client, self, "pd.batPwrOut", "Battery output power"),
-            WattsSensorEntity(client, self, "pd.pvPower", "PV charging power"),
+            WattsSensorEntity(client, self, "pd.pvPower", const.PV_CHARGING_POWER),
             WattsSensorEntity(client, self, "pd.acPwrIn", "AC input power"),
-            WattsSensorEntity(client, self, "pd.psdrPower ", "Power supply power"),
+            WattsSensorEntity(client, self, "pd.psdrPower", "Power supply power"),
             WattsSensorEntity(client, self, "pd.sysPowerWatts", "System power"),
-            WattsSensorEntity(client, self, "pd.batPower ", "Battery power"),
+            WattsSensorEntity(client, self, "pd.batPower", "Battery power"),
 
             # power (motor)
             WattsSensorEntity(client, self, "motor.power", "Motor operating power"),
 
             # power (power)
             WattsSensorEntity(client, self, "power.batPwrOut", "Battery output power"),
-            WattsSensorEntity(client, self, "power.acPwrI", "AC input power"),
-            WattsSensorEntity(client, self, "power.mpptPwr ", "PV input power"),
+            WattsSensorEntity(client, self, "power.acPwrIn", "AC input power"),
+            WattsSensorEntity(client, self, "power.mpptPwr", const.PV_INPUT_POWER),
 
             QuotaStatusSensorEntity(client, self)
         ]
@@ -63,6 +90,20 @@ class Wave2(BaseDevice):
                           lambda value: {"moduleType": 1, "operateType": "setTemp",
                                          "sn": self.device_info.sn,
                                          "params": {"setTemp": int(value)}}),
+            ValueUpdateEntity(
+                client,
+                self,
+                "pd.timeSet",
+                const.TIMER_DURATION,
+                0,
+                65535,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "sacTiming",
+                    "sn": self.device_info.sn,
+                    "params": {"timeSet": int(value), "timeEn": 1},
+                },
+            ),
         ]
 
     def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:
@@ -83,7 +124,53 @@ class Wave2(BaseDevice):
                              lambda value: {"moduleType": 1, "operateType": "subMode",
                                             "sn": self.device_info.sn,
                                             "params": {"subMode": value}}),
+            DictSelectEntity(client, self, "pd.tempSys", const.TEMP_SYS, const.TEMP_SYS_OPTIONS,
+                             lambda value: {"moduleType": 1, "operateType": "tempSys",
+                                            "sn": self.device_info.sn,
+                                            "params": {"mode": value}}),
+            DictSelectEntity(client, self, "pd.tempDisplay", const.TEMP_DISPLAY, const.TEMP_DISPLAY_OPTIONS,
+                             lambda value: {"moduleType": 1, "operateType": "tempDisplay",
+                                            "sn": self.device_info.sn,
+                                            "params": {"tempDisplay": value}}),
+            DictSelectEntity(client, self, "pd.rgbState", const.RGB_STATE, const.RGB_STATE_OPTIONS,
+                             lambda value: {"moduleType": 1, "operateType": "rgbState",
+                                            "sn": self.device_info.sn,
+                                            "params": {"rgbState": value}}),
+            DictSelectEntity(client, self, "pd.wteFthEn", const.AUTO_DRAIN, const.AUTO_DRAIN_OPTIONS,
+                             lambda value: {"moduleType": 1, "operateType": "wteFthEn",
+                                            "sn": self.device_info.sn,
+                                            "params": {"wteFthEn": value}}),
+            TimeoutDictSelectEntity(client, self, "pd.idleTime", const.SCREEN_TIMEOUT, const.SCREEN_TIMEOUT_OPTIONS,
+                                   lambda value: {"moduleType": 1, "operateType": "display",
+                                                  "sn": self.device_info.sn,
+                                                  "params": {"idleTime": value,
+                                                             "idleMode": 0 if value == 0 else 1}}),
         ]
 
-    def switches(self, client: EcoflowApiClient) -> list[SwitchEntity]:
-        return []
+    def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
+        return [
+            InvertedBeeperEntity(
+                client,
+                self,
+                "pd.beepEn",
+                const.BEEPER,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "beepEn",
+                    "sn": self.device_info.sn,
+                    "params": {"en": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.timeEn",
+                const.TIMER_ENABLED,
+                lambda value, params: {
+                    "moduleType": 1,
+                    "operateType": "sacTiming",
+                    "sn": self.device_info.sn,
+                    "params": {"timeEn": value, "timeSet": int(params.get("pd.timeSet", 0))},
+                },
+            ),
+        ]

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -374,6 +374,25 @@ class DecihertzSensorEntity(FrequencySensorEntity):
         return super()._update_value(int(val) / 10)
 
 
+class EnumSensorEntity(BaseSensorEntity):
+    """Map integer values to human readable states."""
+
+    def __init__(
+        self,
+        client: EcoflowApiClient,
+        device: BaseDevice,
+        mqtt_key: str,
+        title: str,
+        mapping: dict[str, int],
+    ):
+        super().__init__(client, device, title, mqtt_key)
+        self._map = {v: k for k, v in mapping.items()}
+
+    def _update_value(self, val: Any) -> bool:
+        sval = self._map.get(int(val), str(val))
+        return super()._update_value(sval)
+
+
 class StatusSensorEntity(SensorEntity, EcoFlowAbstractEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 


### PR DESCRIPTION
## Summary
- expose additional Wave 2 readings like PV voltage/current and AC metrics
- map MPPT work status to readable text
- fix power sensor keys and add new helper class for enumerated sensors

## Testing
- `python -m py_compile custom_components/ecoflow_cloud/devices/internal/wave2.py`
- `python -m py_compile custom_components/ecoflow_cloud/devices/const.py`
- `python -m py_compile custom_components/ecoflow_cloud/sensor.py`


------
https://chatgpt.com/codex/tasks/task_e_68505d117708832f892c0d28c2d8350f