### PR TITLE
Add motor status sensor for Wave 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -934,7 +934,7 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 
 </p></details>
 
-<details><summary> WAVE_2 <i>(sensors: 30, switches: 0, sliders: 1, selects: 4)</i> </summary>
+<details><summary> WAVE_2 <i>(sensors: 31, switches: 0, sliders: 1, selects: 4)</i> </summary>
 <p>
 
 *Sensors*
@@ -956,6 +956,7 @@ Once installed, use Add Integration -> Ecoflow Cloud.
 - Condensing Fan RPM  _(disabled)_
 - Evaporator Fan RPM  _(disabled)_
 - Four-way Valve State  _(disabled)_
+- Motor Status
 - PV input power
 - Battery output power
 - PV charging power

--- a/custom_components/ecoflow_cloud/devices/const.py
+++ b/custom_components/ecoflow_cloud/devices/const.py
@@ -320,6 +320,14 @@ MPPT_WORK = "MPPT Mode"
 CONDENSER_FAN_RPM = "Condensing Fan RPM"
 EVAP_FAN_RPM = "Evaporator Fan RPM"
 FOUR_WAY_VALVE = "Four-way Valve State"
+MOTOR_STATUS = "Motor Status"
+
+MOTOR_STATUS_OPTIONS = {
+    "Off": 0,
+    "Cooling": 1,
+    "Heating": 2,
+    "Fan": 3,
+}
 
 MPPT_WORK_OPTIONS = {
     "Car Charging": 1,

--- a/custom_components/ecoflow_cloud/devices/internal/wave2.py
+++ b/custom_components/ecoflow_cloud/devices/internal/wave2.py
@@ -57,6 +57,7 @@ class Wave2(BaseDevice):
             FanSensorEntity(client, self, "motor.condeFanRpm", const.CONDENSER_FAN_RPM, False),
             FanSensorEntity(client, self, "motor.evapFanRpm", const.EVAP_FAN_RPM, False),
             BaseSensorEntity(client, self, "motor.fourWayState", const.FOUR_WAY_VALVE, False),
+            EnumSensorEntity(client, self, "motor.status", const.MOTOR_STATUS, const.MOTOR_STATUS_OPTIONS, False),
 
             LevelSensorEntity(client, self, "pd.batSoc", const.BATTERY_LEVEL_SOC),
             CentivoltSensorEntity(client, self, "pd.batVolt", const.BATTERY_VOLT, False),

--- a/docs/devices/WAVE_2.md
+++ b/docs/devices/WAVE_2.md
@@ -19,6 +19,7 @@
 - Condensing Fan RPM (`motor.condeFanRpm`)   _(disabled)_
 - Evaporator Fan RPM (`motor.evapFanRpm`)   _(disabled)_
 - Four-way Valve State (`motor.fourWayState`)   _(disabled)_
+- Motor Status (`motor.status`)
 - PV input power (`pd.mpptPwr`)
 - Battery output power (`pd.batPwrOut`)
 - PV charging power (`pd.pvPower`)

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -913,7 +913,7 @@
 
 </p></details>
 
-<details><summary> WAVE_2 <i>(sensors: 30, switches: 0, sliders: 1, selects: 4)</i> </summary>
+<details><summary> WAVE_2 <i>(sensors: 31, switches: 0, sliders: 1, selects: 4)</i> </summary>
 <p>
 
 *Sensors*
@@ -935,6 +935,7 @@
 - Condensing Fan RPM  _(disabled)_
 - Evaporator Fan RPM  _(disabled)_
 - Four-way Valve State  _(disabled)_
+- Motor Status
 - PV input power
 - Battery output power
 - PV charging power


### PR DESCRIPTION
## Summary
- add new `MOTOR_STATUS` constant and options
- expose `motor.status` sensor in Wave 2 device
- document the new sensor and update device counts

## Testing
- `python -m compileall custom_components`

------
https://chatgpt.com/codex/tasks/task_e_68506a038e00832f928be0c3473919d5