### PR TITLE
Fix EnumSensorEntity init argument mismatch

### DIFF
--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -384,8 +384,10 @@ class EnumSensorEntity(BaseSensorEntity):
         mqtt_key: str,
         title: str,
         mapping: dict[str, int],
+        enabled: bool = True,
+        auto_enable: bool = False,
     ):
-        super().__init__(client, device, title, mqtt_key)
+        super().__init__(client, device, mqtt_key, title, enabled, auto_enable)
         self._map = {v: k for k, v in mapping.items()}
 
     def _update_value(self, val: Any) -> bool:


### PR DESCRIPTION
## Summary
- allow optional enabled/auto_enable parameters for EnumSensorEntity
- pass arguments in correct order to BaseSensorEntity

## Testing
- `python -m compileall -q custom_components/ecoflow_cloud`

------
https://chatgpt.com/codex/tasks/task_e_68507117d0b0832f82cd3860137dc91a