### PR TITLE
Support 32bit energy counters on Delta 2

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta2.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta2.py
@@ -17,8 +17,8 @@ from ...sensor import (
     CapacitySensorEntity,
     StatusSensorEntity,
     QuotaStatusSensorEntity,
-    InEnergySensorEntity,
-    OutEnergySensorEntity,
+    InBeEnergySensorEntity,
+    OutBeEnergySensorEntity,
 )
 from ...switch import BeeperEntity, EnabledEntity
 
@@ -81,11 +81,11 @@ class Delta2(BaseDevice):
             MilliVoltSensorEntity(client, self, "bms_bmsStatus.maxCellVol", const.MAX_CELL_VOLT, False),
 
             # cumulative energy values for energy dashboard
-            InEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
-            InEnergySensorEntity(client, self, "pd.chgPowerAC", const.CHARGE_AC_ENERGY),
-            InEnergySensorEntity(client, self, "pd.chgPowerDC", const.CHARGE_DC_ENERGY),
-            OutEnergySensorEntity(client, self, "pd.dsgPowerAC", const.DISCHARGE_AC_ENERGY),
-            OutEnergySensorEntity(client, self, "pd.dsgPowerDC", const.DISCHARGE_DC_ENERGY),
+            InBeEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
+            InBeEnergySensorEntity(client, self, "pd.chgPowerAC", const.CHARGE_AC_ENERGY),
+            InBeEnergySensorEntity(client, self, "pd.chgPowerDC", const.CHARGE_DC_ENERGY),
+            OutBeEnergySensorEntity(client, self, "pd.dsgPowerAC", const.DISCHARGE_AC_ENERGY),
+            OutBeEnergySensorEntity(client, self, "pd.dsgPowerDC", const.DISCHARGE_DC_ENERGY),
 
             # Optional Slave Battery
             LevelSensorEntity(client, self, "bms_slave.soc", const.SLAVE_BATTERY_LEVEL, False, True)

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -271,6 +271,18 @@ class EnergySensorEntity(BaseSensorEntity):
             )
         return result
 
+
+class BeEnergySensorEntity(BeSensorEntity, EnergySensorEntity):
+    """Energy sensor with big-endian 32bit values."""
+
+
+class InBeEnergySensorEntity(BeEnergySensorEntity):
+    _attr_icon = "mdi:transmission-tower-import"
+
+
+class OutBeEnergySensorEntity(BeEnergySensorEntity):
+    _attr_icon = "mdi:transmission-tower-export"
+
 class CapacitySensorEntity(BaseSensorEntity):
     _attr_native_unit_of_measurement = "mAh"
     _attr_state_class = SensorStateClass.MEASUREMENT

--- a/docs/devices/DELTA_2.md
+++ b/docs/devices/DELTA_2.md
@@ -31,6 +31,11 @@
 - Battery Volts (`bms_bmsStatus.vol`)   _(disabled)_
 - Min Cell Volts (`bms_bmsStatus.minCellVol`)   _(disabled)_
 - Max Cell Volts (`bms_bmsStatus.maxCellVol`)   _(disabled)_
+- Solar In Energy (`pd.chgSunPower`)
+- Battery Charge Energy from AC (`pd.chgPowerAC`)
+- Battery Charge Energy from DC (`pd.chgPowerDC`)
+- Battery Discharge Energy to AC (`pd.dsgPowerAC`)
+- Battery Discharge Energy to DC (`pd.dsgPowerDC`)
 - Slave Battery Level (`bms_slave.soc`)   _(auto)_
 - Slave Design Capacity (`bms_slave.designCap`)   _(disabled)_
 - Slave Full Capacity (`bms_slave.fullCap`)   _(disabled)_


### PR DESCRIPTION
## Summary
- add big-endian energy sensor classes
- use big-endian sensors for Delta 2 energy counters
- document Delta 2 energy sensors

## Testing
- `python -m compileall -q custom_components/ecoflow_cloud`

------
https://chatgpt.com/codex/tasks/task_e_685233d83b0c832f9a15061eeacd74ab