### PR TITLE
Update Delta2 energy sensors

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta2.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta2.py
@@ -17,8 +17,8 @@ from ...sensor import (
     CapacitySensorEntity,
     StatusSensorEntity,
     QuotaStatusSensorEntity,
-    InBeEnergySensorEntity,
-    OutBeEnergySensorEntity,
+    InBeLongEnergySensorEntity,
+    OutBeLongEnergySensorEntity,
 )
 from ...switch import BeeperEntity, EnabledEntity
 
@@ -81,11 +81,11 @@ class Delta2(BaseDevice):
             MilliVoltSensorEntity(client, self, "bms_bmsStatus.maxCellVol", const.MAX_CELL_VOLT, False),
 
             # cumulative energy values for energy dashboard
-            InBeEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
-            InBeEnergySensorEntity(client, self, "pd.chgPowerAC", const.CHARGE_AC_ENERGY),
-            InBeEnergySensorEntity(client, self, "pd.chgPowerDC", const.CHARGE_DC_ENERGY),
-            OutBeEnergySensorEntity(client, self, "pd.dsgPowerAC", const.DISCHARGE_AC_ENERGY),
-            OutBeEnergySensorEntity(client, self, "pd.dsgPowerDC", const.DISCHARGE_DC_ENERGY),
+            InBeLongEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
+            InBeLongEnergySensorEntity(client, self, "pd.chgPowerAC", const.CHARGE_AC_ENERGY),
+            InBeLongEnergySensorEntity(client, self, "pd.chgPowerDC", const.CHARGE_DC_ENERGY),
+            OutBeLongEnergySensorEntity(client, self, "pd.dsgPowerAC", const.DISCHARGE_AC_ENERGY),
+            OutBeLongEnergySensorEntity(client, self, "pd.dsgPowerDC", const.DISCHARGE_DC_ENERGY),
 
             # Optional Slave Battery
             LevelSensorEntity(client, self, "bms_slave.soc", const.SLAVE_BATTERY_LEVEL, False, True)

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -173,6 +173,15 @@ class BeSensorEntity(BaseSensorEntity):
         )
 
 
+class BeLongSensorEntity(BaseSensorEntity):
+    """Sensor with big-endian 64bit values."""
+
+    def _update_value(self, val: Any) -> bool:
+        return super()._update_value(
+            int(struct.unpack("<Q", struct.pack(">Q", val))[0])
+        )
+
+
 class BeMilliVoltSensorEntity(BeSensorEntity):
     _attr_device_class = SensorDeviceClass.VOLTAGE
     _attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -281,6 +290,18 @@ class InBeEnergySensorEntity(BeEnergySensorEntity):
 
 
 class OutBeEnergySensorEntity(BeEnergySensorEntity):
+    _attr_icon = "mdi:transmission-tower-export"
+
+
+class BeLongEnergySensorEntity(BeLongSensorEntity, EnergySensorEntity):
+    """Energy sensor with big-endian 64bit values."""
+
+
+class InBeLongEnergySensorEntity(BeLongEnergySensorEntity):
+    _attr_icon = "mdi:transmission-tower-import"
+
+
+class OutBeLongEnergySensorEntity(BeLongEnergySensorEntity):
     _attr_icon = "mdi:transmission-tower-export"
 
 class CapacitySensorEntity(BaseSensorEntity):


### PR DESCRIPTION
## Summary
- support big endian 64-bit sensor values
- switch Delta2 energy sensors to use the new 64-bit type

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6852371bba3c832fa3c48535dc031c46