### PR TITLE
Expose PowerStream sliders via private API

### DIFF
--- a/docs/devices/POWERSTREAM.md
+++ b/docs/devices/POWERSTREAM.md
@@ -69,6 +69,10 @@
 - Feed-in Control (`20_1.feedProtect` -> `{"from": "HomeAssistant", "id": "999978134", "version": "1.0", "sn": "SN", "cmdCode": "PRIVATE_API_POWERSTREAM_SET_FEED_PROTECT", "params": {"value": "VALUE"}}`)
 
 *Sliders (numbers)*
+- Min Discharge Level (`20_1.lowerLimit` -> `{"from": "HomeAssistant", "id": "999965037", "version": "1.0", "sn": "SN", "cmdCode": "WN511_SET_BAT_LOWER_PACK", "params": {"lowerLimit": "VALUE"}}` [0 - 30])
+- Max Charge Level (`20_1.upperLimit` -> `{"from": "HomeAssistant", "id": "999965037", "version": "1.0", "sn": "SN", "cmdCode": "WN511_SET_BAT_UPPER_PACK", "params": {"upperLimit": "VALUE"}}` [70 - 100])
+- Brightness (`20_1.invBrightness` -> `{"from": "HomeAssistant", "id": "999965037", "version": "1.0", "sn": "SN", "cmdCode": "WN511_SET_BRIGHTNESS_PACK", "params": {"brightness": "VALUE"}}` [0 - 1023])
+- Custom load power settings (`20_1.permanentWatts` -> `{"from": "HomeAssistant", "id": "999965037", "version": "1.0", "sn": "SN", "cmdCode": "WN511_SET_PERMANENT_WATTS_PACK", "params": {"permanentWatts": "VALUE"}}` [0 - 600])
 
 *Selects*
 - Power supply mode (`20_1.supplyPriority` -> `{"from": "HomeAssistant", "id": "999965037", "version": "1.0", "sn": "SN", "cmdCode": "WN511_SET_SUPPLY_PRIORITY_PACK", "params": {"supplyPriority": "VALUE"}}` [Prioritize power supply (0), Prioritize power storage (1)])

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -791,7 +791,7 @@
 
 </p></details>
 
-<details><summary> POWERSTREAM <i>(sensors: 63, switches: 1, sliders: 0, selects: 1)</i> </summary>
+<details><summary> POWERSTREAM <i>(sensors: 63, switches: 1, sliders: 4, selects: 1)</i> </summary>
 <p>
 
 *Sensors*
@@ -863,6 +863,11 @@
 - Feed-in Control 
 
 *Sliders (numbers)*
+
+- Min Discharge Level
+- Max Charge Level
+- Brightness
+- Custom load power settings
 
 *Selects*
 - Power supply mode 


### PR DESCRIPTION
## Summary
- import number entity classes in private PowerStream
- expose min/max battery, brightness and custom load sliders via private API
- document new sliders for POWERSTREAM device
- update summary listing sliders

## Testing
- `python -m py_compile custom_components/ecoflow_cloud/devices/internal/powerstream.py`

------
https://chatgpt.com/codex/tasks/task_e_687e70c1b1b0832fae24873e174e394a