### PR TITLE
Fix parsing of malformed MQTT messages

### DIFF
--- a/custom_components/ecoflow_cloud/devices/__init__.py
+++ b/custom_components/ecoflow_cloud/devices/__init__.py
@@ -206,7 +206,10 @@ class BaseDevice(ABC):
         """Decode incoming bytes and return JSON payload if possible."""
         try:
             payload = raw_data.decode("utf-8", errors="ignore")
-            return json.loads(payload)
+            decoder = json.JSONDecoder()
+            payload = payload.lstrip()
+            payload_dict, _ = decoder.raw_decode(payload)
+            return payload_dict
         except Exception as error:
             _LOGGER.error(
                 "Failed to parse incoming message: %s. Ignoring message and waiting for the next one.",


### PR DESCRIPTION
## Summary
- improve robustness of JSON message parsing

## Testing
- `python3 -m homeassistant.scripts.hassfest .` *(fails: No module named homeassistant.scripts.hassfest)*

------
https://chatgpt.com/codex/tasks/task_e_68812d5df470832f97fc06f0ab45461b