### PR TITLE
Fix reconnect loop_stop call

### DIFF
--- a/custom_components/ecoflow_cloud/api/ecoflow_mqtt.py
+++ b/custom_components/ecoflow_cloud/api/ecoflow_mqtt.py
@@ -55,7 +55,13 @@ class EcoflowMQTTClient:
             _LOGGER.info(
                 f"Re-connecting to MQTT Broker {self.__mqtt_info.url}:{self.__mqtt_info.port}"
             )
-            self.__client.loop_stop(True)
+            # AsyncMQTTClient.loop_stop does not accept positional arguments
+            # The original call passed ``True`` as the ``force`` parameter,
+            # which raises ``Client.loop_stop() takes 1 positional argument but 2 were given``
+            # in recent Home Assistant releases. Since ``force`` defaults to
+            # ``True`` inside the implementation, simply call the method
+            # without arguments to stop the loop.
+            self.__client.loop_stop()
             self.__client.reconnect()
             self.__client.loop_start()
             return True


### PR DESCRIPTION
## Summary
- fix `EcoflowMQTTClient.reconnect` stopping the MQTT loop with a positional parameter

## Testing
- `python -m compileall custom_components`

------
https://chatgpt.com/codex/tasks/task_e_688132ded0f4832f88bea45c11f5159f