### PR TITLE
Add protobuf decoding fallback

### DIFF
--- a/custom_components/ecoflow_cloud/devices/__init__.py
+++ b/custom_components/ecoflow_cloud/devices/__init__.py
@@ -211,6 +211,14 @@ class BaseDevice(ABC):
             payload_dict, _ = decoder.raw_decode(payload)
             return payload_dict
         except Exception as error:
+            try:
+                from ..proto_decode import decode_ecopacket
+
+                decoded = decode_ecopacket(raw_data)
+                if decoded is not None:
+                    return decoded
+            except Exception as proto_error:  # pragma: no cover - fallback only
+                _LOGGER.debug("Failed protobuf decode: %s", proto_error)
             _LOGGER.error(
                 "Failed to parse incoming message: %s. Ignoring message and waiting for the next one.",
                 error,

--- a/custom_components/ecoflow_cloud/proto_decode.py
+++ b/custom_components/ecoflow_cloud/proto_decode.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from google.protobuf.json_format import MessageToDict
+
+from .devices.internal.proto import ecopacket_pb2, powerstream_pb2
+
+
+def decode_ecopacket(raw_data: bytes) -> Dict[str, Any] | None:
+    """Decode EcoFlow protobuf message using powerstream definitions."""
+    try:
+        packet = ecopacket_pb2.SendHeaderMsg()
+        packet.ParseFromString(raw_data)
+    except Exception:
+        return None
+
+    result: Dict[str, Any] = {"params": {}}
+    for message in packet.msg:
+        if message.cmd_id == 1:
+            heartbeat = powerstream_pb2.InverterHeartbeat()
+            try:
+                heartbeat.ParseFromString(message.pdata)
+                result["params"].update(
+                    MessageToDict(heartbeat, preserving_proto_field_name=False)
+                )
+            except Exception:
+                result["params"]["raw_payload"] = message.pdata.hex()
+        else:
+            result["params"][f"cmd_{message.cmd_func}_{message.cmd_id}"] = message.pdata.hex()
+    return result


### PR DESCRIPTION
## Summary
- add a simple decoder for EcoFlow protobuf packets
- use decoder when JSON parsing fails

## Testing
- `python -m py_compile custom_components/ecoflow_cloud/proto_decode.py`
- `python -m py_compile custom_components/ecoflow_cloud/devices/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_688134394b38832fa142bbeacd7f2a93