### PR TITLE
Fix DC enabled switch for Delta Pro 3

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
@@ -19,6 +19,10 @@ from custom_components.ecoflow_cloud.sensor import (
     LevelSensorEntity,
     OutWattsSensorEntity,
     RemainSensorEntity,
+    TempSensorEntity,
+    VoltSensorEntity,
+    AmpSensorEntity,
+    FrequencySensorEntity,
 )
 from custom_components.ecoflow_cloud.switch import BeeperEntity, EnabledEntity
 from custom_components.ecoflow_cloud.devices import BaseDevice, const
@@ -202,7 +206,7 @@ class DeltaPro3(BaseDevice):
             EnabledEntity(
                 client,
                 self,
-                "flowInfoDc12v",
+                "flowInfo12v",
                 const.DC_ENABLED,
                 lambda value: {
                     "sn": self.device_info.sn,

--- a/custom_components/ecoflow_cloud/devices/public/delta_pro_3.py
+++ b/custom_components/ecoflow_cloud/devices/public/delta_pro_3.py
@@ -27,6 +27,10 @@ from ...sensor import (
     LevelSensorEntity,
     OutWattsSensorEntity,
     RemainSensorEntity,
+    TempSensorEntity,
+    VoltSensorEntity,
+    AmpSensorEntity,
+    FrequencySensorEntity,
 )
 from ...switch import BeeperEntity, EnabledEntity
 from .. import BaseDevice, const
@@ -210,7 +214,7 @@ class DeltaPro3(BaseDevice):
             EnabledEntity(
                 client,
                 self,
-                "flowInfoDc12v",
+                "flowInfo12v",
                 const.DC_ENABLED,
                 lambda value: {
                     "sn": self.device_info.sn,


### PR DESCRIPTION
## Summary
- correct DC 12V switch key for Delta Pro 3 devices
- include missing sensor imports for Delta Pro 3 device classes

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 -m hassfest` *(fails: module not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882269da4dc832fb61f01aa251ec999