### PR TITLE
Fix DeltaPro3 protobuf header field

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
@@ -54,7 +54,10 @@ class DeltaPro3SetMessage(Message, PrivateAPIMessageProtocol):
         header.seq = JSONMessage.gen_seq()
         header.version = 19
         header.payload_ver = 1
-        header.from_ = "HomeAssistant"
+        # The generated protobuf uses the reserved word "from" as a field name.
+        # Since Python does not allow using "from" directly as an attribute, use
+        # ``setattr`` to set the value.
+        setattr(header, "from", "HomeAssistant")
         header.device_sn = self.device_sn
         header.data_len = self.data_len
         setattr(header.pdata, self.field, int(self.value))


### PR DESCRIPTION
## Summary
- fix protobuf header assignment by using `setattr` for reserved field

## Testing
- `python -m compileall -q custom_components/ecoflow_cloud`


------
https://chatgpt.com/codex/tasks/task_e_6882407f5964832f916898f42a3c8f80