### PR TITLE
Fix DeltaPro3 AC switch

### DIFF
--- a/custom_components/ecoflow_cloud/switch.py
+++ b/custom_components/ecoflow_cloud/switch.py
@@ -55,7 +55,8 @@ class EnabledEntity(BaseSwitchEntity[int]):
 
     def turn_on(self, **kwargs: Any) -> None:
         if self._command:
-            self.send_set_message(1, self.command_dict(1))
+            value = 1 if self._enable_value is None else self._enable_value
+            self.send_set_message(value, self.command_dict(value))
 
     def turn_off(self, **kwargs: Any) -> None:
         if self._command:


### PR DESCRIPTION
## Summary
- respect custom enable values when turning on a switch

## Testing
- `python -m compileall -q custom_components/ecoflow_cloud/switch.py`


------
https://chatgpt.com/codex/tasks/task_e_68825874f3cc832f9701dc936a02095e