### PR TITLE
Fix DeltaPro3 AC switch

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
@@ -248,15 +248,9 @@ class DeltaPro3(BaseDevice):
                 self,
                 "flowInfoAcHvOut",
                 const.AC_ENABLED,
-                lambda value: {
-                    "sn": self.device_info.sn,
-                    "cmdId": 17,
-                    "dirDest": 1,
-                    "dirSrc": 1,
-                    "cmdFunc": 254,
-                    "dest": 2,
-                    "params": {"cfgHvAcOutOpen": value},
-                },
+                lambda value: DeltaPro3SetMessage(
+                    self.device_info.sn, "cfgHvAcOutOpen", value
+                ),
                 enableValue=2,
             ),
             EnabledEntity(

--- a/custom_components/ecoflow_cloud/switch.py
+++ b/custom_components/ecoflow_cloud/switch.py
@@ -55,7 +55,8 @@ class EnabledEntity(BaseSwitchEntity[int]):
 
     def turn_on(self, **kwargs: Any) -> None:
         if self._command:
-            self.send_set_message(1, self.command_dict(1))
+            value = 1 if self._enable_value is None else self._enable_value
+            self.send_set_message(value, self.command_dict(value))
 
     def turn_off(self, **kwargs: Any) -> None:
         if self._command:


### PR DESCRIPTION
## Summary
- restore DeltaPro3 AC switch to use the private API protobuf message

## Testing
- `python -m compileall -q custom_components/ecoflow_cloud/switch.py`
- `python -m compileall -q custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py`


------
https://chatgpt.com/codex/tasks/task_e_68825874f3cc832f9701dc936a02095e