### PR TITLE
Format code with black

### DIFF
--- a/custom_components/ecoflow_cloud/config_flow.py
+++ b/custom_components/ecoflow_cloud/config_flow.py
@@ -149,7 +149,7 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
         _LOGGER.debug(".. getting device by %s: %s", str(identifiers), str(device))
 
         # Remove all entities for this device
-        if getattr(device, "id", None) is not None :
+        if getattr(device, "id", None) is not None:
             ent_reg: EntityRegistry = er.async_get(self.hass)
             entities = er.async_entries_for_device(ent_reg, device.id)
 
@@ -461,7 +461,9 @@ class EcoflowConfigFlow(ConfigFlow, domain=ECOFLOW_DOMAIN):
         self.new_options[CONF_DEVICE_LIST][sn] = {
             OPTS_REFRESH_PERIOD_SEC: DEFAULT_REFRESH_PERIOD_SEC,
             OPTS_POWER_STEP: device.default_charging_power_step(),
-            OPTS_DIAGNOSTIC_MODE: ("Diagnostic".lower() == user_input[CONF_DEVICE_TYPE].lower()),
+            OPTS_DIAGNOSTIC_MODE: (
+                "Diagnostic".lower() == user_input[CONF_DEVICE_TYPE].lower()
+            ),
         }
 
         return await self.update_or_create()

--- a/custom_components/ecoflow_cloud/devices/const.py
+++ b/custom_components/ecoflow_cloud/devices/const.py
@@ -27,7 +27,7 @@ UNIT_TIMEOUT_OPTIONS = {
     "4 hr": 240,
     "6 hr": 360,
     "12 hr": 720,
-    "24 hr": 1440
+    "24 hr": 1440,
 }
 
 UNIT_TIMEOUT_OPTIONS_LIMITED = {
@@ -36,7 +36,7 @@ UNIT_TIMEOUT_OPTIONS_LIMITED = {
     "1 hr": 60,
     "2 hr": 120,
     "6 hr": 360,
-    "12 hr": 720
+    "12 hr": 720,
 }
 
 AC_TIMEOUT_OPTIONS = {
@@ -79,36 +79,15 @@ DC_TIMEOUT_OPTIONS_LIMITED = {
     "24 hr": 1440,
 }
 
-DC_CHARGE_CURRENT_OPTIONS = {
-    "4A": 4000,
-    "6A": 6000,
-    "8A": 8000
-}
+DC_CHARGE_CURRENT_OPTIONS = {"4A": 4000, "6A": 6000, "8A": 8000}
 
-MAIN_MODE_OPTIONS = {
-    "Cool": 0,
-    "Heat": 1,
-    "Fan": 2
-}
+MAIN_MODE_OPTIONS = {"Cool": 0, "Heat": 1, "Fan": 2}
 
-FAN_MODE_OPTIONS = {
-    "Low": 0,
-    "Medium": 1,
-    "High": 2
-}
+FAN_MODE_OPTIONS = {"Low": 0, "Medium": 1, "High": 2}
 
-REMOTE_MODE_OPTIONS = {
-    "Startup": 1,
-    "Standby": 2,
-    "Shutdown": 3
-}
+REMOTE_MODE_OPTIONS = {"Startup": 1, "Standby": 2, "Shutdown": 3}
 
-POWER_SUB_MODE_OPTIONS = {
-    "Max": 0,
-    "Sleep": 1,
-    "Eco": 2,
-    "Manual": 3
-}
+POWER_SUB_MODE_OPTIONS = {"Max": 0, "Sleep": 1, "Eco": 2, "Manual": 3}
 
 TEMP_SYS_OPTIONS = {
     "Celsius": 0,
@@ -135,7 +114,7 @@ AUTO_DRAIN_OPTIONS = {
 
 POWER_SUPPLY_PRIORITY_OPTIONS = {
     "Prioritize power supply": 0,
-    "Prioritize power storage": 1
+    "Prioritize power storage": 1,
 }
 
 COMBINED_BATTERY_LEVEL = "Battery Level"
@@ -372,10 +351,16 @@ SMART_METER_RECORD_ACTIVE_TODAY_L2 = "L2 Lifetime net usage"
 SMART_METER_RECORD_ACTIVE_TODAY_L3 = "L3 Lifetime net usage"
 
 # Stream AC
-STREAM_POWER_AC = "Power AC" # <0 import from home to battery / >0 export from battery to home
-STREAM_POWER_VOL = "Power Volts" # <0 import from home to battery / >0 export from battery to home
+STREAM_POWER_AC = (
+    "Power AC"  # <0 import from home to battery / >0 export from battery to home
+)
+STREAM_POWER_VOL = (
+    "Power Volts"  # <0 import from home to battery / >0 export from battery to home
+)
 STREAM_POWER_AMP = "Power In Amps"
-STREAM_POWER_AC_SYS = "Power AC SYS" # <0 import from home to battery / >0 export from battery to home
+STREAM_POWER_AC_SYS = (
+    "Power AC SYS"  # <0 import from home to battery / >0 export from battery to home
+)
 STREAM_POWER_PV_1 = "Power PV 1"
 STREAM_POWER_PV_2 = "Power PV 2"
 STREAM_POWER_PV_3 = "Power PV 3"
@@ -385,15 +370,17 @@ STREAM_IN_AMPS_PV_2 = "Power PV2 In Amps"
 STREAM_IN_VOL_PV_1 = "Power PV1 Volts"
 STREAM_IN_VOL_PV_2 = "Power PV2 Volts"
 STREAM_POWER_PV_SUM = "Power PV Sum"
-STREAM_GET_SYS_LOAD = "Power Sys Load" # powGetSysLoad
-STREAM_GET_SYS_LOAD_FROM_BP = "Power Sys Load From Battery" # powGetSysLoadFromBp
-STREAM_GET_SYS_LOAD_FROM_GRID = "Power Sys Load From Grid" # powGetSysLoadFromGrid
-STREAM_GET_SYS_LOAD_FROM_PV = "Power Sys Load From PV" # powGetSysLoadFromPv
-STREAM_GET_SCHUKO1 = "Power SCHUKO1" # powGetSchuko1
-STREAM_GET_SCHUKO2 = "Power SCHUKO2" # powGetSchuko2
-STREAM_POWER_GRID = "Power Grid" # power from smart meter or shelly
-STREAM_POWER_BATTERY = "Power Battery" # <0 discharge battery / >0 charge batterie
-STREAM_POWER_BATTERY_SOC = "Power Battery SOC" # <0 discharge battery / >0 charge batterie
+STREAM_GET_SYS_LOAD = "Power Sys Load"  # powGetSysLoad
+STREAM_GET_SYS_LOAD_FROM_BP = "Power Sys Load From Battery"  # powGetSysLoadFromBp
+STREAM_GET_SYS_LOAD_FROM_GRID = "Power Sys Load From Grid"  # powGetSysLoadFromGrid
+STREAM_GET_SYS_LOAD_FROM_PV = "Power Sys Load From PV"  # powGetSysLoadFromPv
+STREAM_GET_SCHUKO1 = "Power SCHUKO1"  # powGetSchuko1
+STREAM_GET_SCHUKO2 = "Power SCHUKO2"  # powGetSchuko2
+STREAM_POWER_GRID = "Power Grid"  # power from smart meter or shelly
+STREAM_POWER_BATTERY = "Power Battery"  # <0 discharge battery / >0 charge batterie
+STREAM_POWER_BATTERY_SOC = (
+    "Power Battery SOC"  # <0 discharge battery / >0 charge batterie
+)
 STREAM_BATTERY_LEVEL = "Battery Level"
 STREAM_DESIGN_CAPACITY = "Design Capacity"
 STREAM_FULL_CAPACITY = "Full Capacity"
@@ -417,28 +404,16 @@ SLAVE_N_ACCU_CHARGE_ENERGY = "Slave %i Cumulative Energy Charge (Wh)"
 SLAVE_N_ACCU_DISCHARGE_CAP = "Slave %i Cumulative Capacity Discharge (mAh)"
 SLAVE_N_ACCU_DISCHARGE_ENERGY = "Slave %i Cumulative Energy Discharge (Wh)"
 
-#Smart Home Pannel 2
+# Smart Home Pannel 2
 
 BATTERIE_STATUS = "Batterie Status"
 
-BATTERIE_STATUS_OPTIONS = {
-    "No operation": 0,
-    "Enabled": 1,
-    "Disabled": 2
-}
+BATTERIE_STATUS_OPTIONS = {"No operation": 0, "Enabled": 1, "Disabled": 2}
 
 BATTERIE_FORCE_CHARGE = "Batterie Force Charge"
 
-BATTERIE_FORCE_CHARGE_OPTIONS =  {
-    "Off": "FORCE_CHARGE_OFF",
-    "On": "FORCE_CHARGE_ON"
-}
+BATTERIE_FORCE_CHARGE_OPTIONS = {"Off": "FORCE_CHARGE_OFF", "On": "FORCE_CHARGE_ON"}
 
 SMART_BACKUP_MODE = "Economic Mode"
 
-SMART_BACKUP_MODE_OPTIONS = {
-    "None": 0,
-    "TOU" : 1,
-    "Self-service" : 2,
-    "Timed task": 3
-}
+SMART_BACKUP_MODE_OPTIONS = {"None": 0, "TOU": 1, "Self-service": 2, "Timed task": 3}

--- a/custom_components/ecoflow_cloud/devices/internal/delta2.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta2.py
@@ -1,8 +1,19 @@
 from .. import const, BaseDevice
 from ...api import EcoflowApiClient
-from ...entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, BaseSelectEntity
-from ...number import ChargingPowerEntity, MinBatteryLevelEntity, MaxBatteryLevelEntity, \
-    MaxGenStopLevelEntity, MinGenStartLevelEntity, BatteryBackupLevel
+from ...entities import (
+    BaseSensorEntity,
+    BaseNumberEntity,
+    BaseSwitchEntity,
+    BaseSelectEntity,
+)
+from ...number import (
+    ChargingPowerEntity,
+    MinBatteryLevelEntity,
+    MaxBatteryLevelEntity,
+    MaxGenStopLevelEntity,
+    MinGenStartLevelEntity,
+    BatteryBackupLevel,
+)
 from ...select import DictSelectEntity, TimeoutDictSelectEntity
 from ...sensor import (
     LevelSensorEntity,
@@ -27,187 +38,422 @@ class Delta2(BaseDevice):
 
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
-            LevelSensorEntity(client, self, "bms_bmsStatus.soc", const.MAIN_BATTERY_LEVEL)
+            LevelSensorEntity(
+                client, self, "bms_bmsStatus.soc", const.MAIN_BATTERY_LEVEL
+            )
             .attr("bms_bmsStatus.designCap", const.ATTR_DESIGN_CAPACITY, 0)
             .attr("bms_bmsStatus.fullCap", const.ATTR_FULL_CAPACITY, 0)
             .attr("bms_bmsStatus.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.designCap", const.MAIN_DESIGN_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.fullCap", const.MAIN_FULL_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.remainCap", const.MAIN_REMAIN_CAPACITY, False),
-
+            CapacitySensorEntity(
+                client,
+                self,
+                "bms_bmsStatus.designCap",
+                const.MAIN_DESIGN_CAPACITY,
+                False,
+            ),
+            CapacitySensorEntity(
+                client, self, "bms_bmsStatus.fullCap", const.MAIN_FULL_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bms_bmsStatus.remainCap",
+                const.MAIN_REMAIN_CAPACITY,
+                False,
+            ),
             LevelSensorEntity(client, self, "bms_bmsStatus.soh", const.SOH),
-
-            LevelSensorEntity(client, self, "bms_emsStatus.lcdShowSoc", const.COMBINED_BATTERY_LEVEL),
+            LevelSensorEntity(
+                client, self, "bms_emsStatus.lcdShowSoc", const.COMBINED_BATTERY_LEVEL
+            ),
             InWattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             OutWattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
-
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
-
             InMilliVoltSensorEntity(client, self, "inv.acInVol", const.AC_IN_VOLT),
             OutMilliVoltSensorEntity(client, self, "inv.invOutVol", const.AC_OUT_VOLT),
-
             InWattsSensorEntity(client, self, "mppt.inWatts", const.SOLAR_IN_POWER),
-
             # OutWattsSensorEntity(client, self, "pd.carWatts", const.DC_OUT_POWER),
             # the same value as pd.carWatts
             OutWattsSensorEntity(client, self, "mppt.outWatts", const.DC_OUT_POWER),
-
-            OutWattsSensorEntity(client, self, "pd.typec1Watts", const.TYPEC_1_OUT_POWER),
-            OutWattsSensorEntity(client, self, "pd.typec2Watts", const.TYPEC_2_OUT_POWER),
-
+            OutWattsSensorEntity(
+                client, self, "pd.typec1Watts", const.TYPEC_1_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "pd.typec2Watts", const.TYPEC_2_OUT_POWER
+            ),
             OutWattsSensorEntity(client, self, "pd.usb1Watts", const.USB_1_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb2Watts", const.USB_2_OUT_POWER),
-
-            OutWattsSensorEntity(client, self, "pd.qcUsb1Watts", const.USB_QC_1_OUT_POWER),
-            OutWattsSensorEntity(client, self, "pd.qcUsb2Watts", const.USB_QC_2_OUT_POWER),
-
-            RemainSensorEntity(client, self, "bms_emsStatus.chgRemainTime", const.CHARGE_REMAINING_TIME),
-            RemainSensorEntity(client, self, "bms_emsStatus.dsgRemainTime", const.DISCHARGE_REMAINING_TIME),
-
+            OutWattsSensorEntity(
+                client, self, "pd.qcUsb1Watts", const.USB_QC_1_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "pd.qcUsb2Watts", const.USB_QC_2_OUT_POWER
+            ),
+            RemainSensorEntity(
+                client, self, "bms_emsStatus.chgRemainTime", const.CHARGE_REMAINING_TIME
+            ),
+            RemainSensorEntity(
+                client,
+                self,
+                "bms_emsStatus.dsgRemainTime",
+                const.DISCHARGE_REMAINING_TIME,
+            ),
             TempSensorEntity(client, self, "inv.outTemp", "Inv Out Temperature"),
             CyclesSensorEntity(client, self, "bms_bmsStatus.cycles", const.CYCLES),
-
             TempSensorEntity(client, self, "bms_bmsStatus.temp", const.BATTERY_TEMP)
             .attr("bms_bmsStatus.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
             .attr("bms_bmsStatus.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            TempSensorEntity(client, self, "bms_bmsStatus.minCellTemp", const.MIN_CELL_TEMP, False),
-            TempSensorEntity(client, self, "bms_bmsStatus.maxCellTemp", const.MAX_CELL_TEMP, False),
-
-            MilliVoltSensorEntity(client, self, "bms_bmsStatus.vol", const.BATTERY_VOLT, False)
+            TempSensorEntity(
+                client, self, "bms_bmsStatus.minCellTemp", const.MIN_CELL_TEMP, False
+            ),
+            TempSensorEntity(
+                client, self, "bms_bmsStatus.maxCellTemp", const.MAX_CELL_TEMP, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bms_bmsStatus.vol", const.BATTERY_VOLT, False
+            )
             .attr("bms_bmsStatus.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
             .attr("bms_bmsStatus.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            MilliVoltSensorEntity(client, self, "bms_bmsStatus.minCellVol", const.MIN_CELL_VOLT, False),
-            MilliVoltSensorEntity(client, self, "bms_bmsStatus.maxCellVol", const.MAX_CELL_VOLT, False),
-
+            MilliVoltSensorEntity(
+                client, self, "bms_bmsStatus.minCellVol", const.MIN_CELL_VOLT, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bms_bmsStatus.maxCellVol", const.MAX_CELL_VOLT, False
+            ),
             # cumulative energy values for energy dashboard
-            InBeEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
-            InBeEnergySensorEntity(client, self, "pd.chgPowerAC", const.CHARGE_AC_ENERGY),
-            InBeEnergySensorEntity(client, self, "pd.chgPowerDC", const.CHARGE_DC_ENERGY),
-            OutBeEnergySensorEntity(client, self, "pd.dsgPowerAC", const.DISCHARGE_AC_ENERGY),
-            OutBeEnergySensorEntity(client, self, "pd.dsgPowerDC", const.DISCHARGE_DC_ENERGY),
-
+            InBeEnergySensorEntity(
+                client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY
+            ),
+            InBeEnergySensorEntity(
+                client, self, "pd.chgPowerAC", const.CHARGE_AC_ENERGY
+            ),
+            InBeEnergySensorEntity(
+                client, self, "pd.chgPowerDC", const.CHARGE_DC_ENERGY
+            ),
+            OutBeEnergySensorEntity(
+                client, self, "pd.dsgPowerAC", const.DISCHARGE_AC_ENERGY
+            ),
+            OutBeEnergySensorEntity(
+                client, self, "pd.dsgPowerDC", const.DISCHARGE_DC_ENERGY
+            ),
             # Optional Slave Battery
-            LevelSensorEntity(client, self, "bms_slave.soc", const.SLAVE_BATTERY_LEVEL, False, True)
+            LevelSensorEntity(
+                client, self, "bms_slave.soc", const.SLAVE_BATTERY_LEVEL, False, True
+            )
             .attr("bms_slave.designCap", const.ATTR_DESIGN_CAPACITY, 0)
             .attr("bms_slave.fullCap", const.ATTR_FULL_CAPACITY, 0)
             .attr("bms_slave.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bms_slave.designCap", const.SLAVE_DESIGN_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bms_slave.fullCap", const.SLAVE_FULL_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bms_slave.remainCap", const.SLAVE_REMAIN_CAPACITY, False),
-
+            CapacitySensorEntity(
+                client, self, "bms_slave.designCap", const.SLAVE_DESIGN_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bms_slave.fullCap", const.SLAVE_FULL_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bms_slave.remainCap", const.SLAVE_REMAIN_CAPACITY, False
+            ),
             LevelSensorEntity(client, self, "bms_slave.soh", const.SLAVE_SOH),
-            TempSensorEntity(client, self, "bms_slave.temp", const.SLAVE_BATTERY_TEMP, False, True)
+            TempSensorEntity(
+                client, self, "bms_slave.temp", const.SLAVE_BATTERY_TEMP, False, True
+            )
             .attr("bms_slave.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
             .attr("bms_slave.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            TempSensorEntity(client, self, "bms_slave.minCellTemp", const.SLAVE_MIN_CELL_TEMP, False),
-            TempSensorEntity(client, self, "bms_slave.maxCellTemp", const.SLAVE_MAX_CELL_TEMP, False),
-
-            MilliVoltSensorEntity(client, self, "bms_slave.vol", const.SLAVE_BATTERY_VOLT, False)
+            TempSensorEntity(
+                client, self, "bms_slave.minCellTemp", const.SLAVE_MIN_CELL_TEMP, False
+            ),
+            TempSensorEntity(
+                client, self, "bms_slave.maxCellTemp", const.SLAVE_MAX_CELL_TEMP, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bms_slave.vol", const.SLAVE_BATTERY_VOLT, False
+            )
             .attr("bms_slave.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
             .attr("bms_slave.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            MilliVoltSensorEntity(client, self, "bms_slave.minCellVol", const.SLAVE_MIN_CELL_VOLT, False),
-            MilliVoltSensorEntity(client, self, "bms_slave.maxCellVol", const.SLAVE_MAX_CELL_VOLT, False),
-
-            CyclesSensorEntity(client, self, "bms_slave.cycles", const.SLAVE_CYCLES, False, True),
-            InWattsSensorEntity(client, self, "bms_slave.inputWatts", const.SLAVE_IN_POWER, False, True),
-            OutWattsSensorEntity(client, self, "bms_slave.outputWatts", const.SLAVE_OUT_POWER, False, True),
+            MilliVoltSensorEntity(
+                client, self, "bms_slave.minCellVol", const.SLAVE_MIN_CELL_VOLT, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bms_slave.maxCellVol", const.SLAVE_MAX_CELL_VOLT, False
+            ),
+            CyclesSensorEntity(
+                client, self, "bms_slave.cycles", const.SLAVE_CYCLES, False, True
+            ),
+            InWattsSensorEntity(
+                client, self, "bms_slave.inputWatts", const.SLAVE_IN_POWER, False, True
+            ),
+            OutWattsSensorEntity(
+                client,
+                self,
+                "bms_slave.outputWatts",
+                const.SLAVE_OUT_POWER,
+                False,
+                True,
+            ),
             self._status_sensor(client),
-
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return [
-            MaxBatteryLevelEntity(client, self, "bms_emsStatus.maxChargeSoc", const.MAX_CHARGE_LEVEL, 50, 100,
-                                  lambda value: {"moduleType": 2, "operateType": "upsConfig",
-                                                 "params": {"maxChgSoc": int(value)}}),
-
-            MinBatteryLevelEntity(client, self, "bms_emsStatus.minDsgSoc", const.MIN_DISCHARGE_LEVEL, 0, 30,
-                                  lambda value: {"moduleType": 2, "operateType": "dsgCfg",
-                                                 "params": {"minDsgSoc": int(value)}}),
-
-            BatteryBackupLevel(client, self, "pd.bpPowerSoc", const.BACKUP_RESERVE_LEVEL, 5, 100,
-                               "bms_emsStatus.minDsgSoc", "bms_emsStatus.maxChargeSoc",
-                               lambda value: {"moduleType": 1, "operateType": "watthConfig",
-                                              "params": {"isConfig": 1, "bpPowerSoc": int(value), "minDsgSoc": 0,
-                                                         "minChgSoc": 0}}),
-
-            MinGenStartLevelEntity(client, self, "bms_emsStatus.minOpenOilEb", const.GEN_AUTO_START_LEVEL, 0, 30,
-                                   lambda value: {"moduleType": 2, "operateType": "openOilSoc",
-                                                  "params": {"openOilSoc": value}}),
-
-            MaxGenStopLevelEntity(client, self, "bms_emsStatus.maxCloseOilEb", const.GEN_AUTO_STOP_LEVEL, 50, 100,
-                                  lambda value: {"moduleType": 2, "operateType": "closeOilSoc",
-                                                 "params": {"closeOilSoc": value}}),
-
-            ChargingPowerEntity(client, self, "mppt.cfgChgWatts", const.AC_CHARGING_POWER, 200, 1200,
-                                lambda value: {"moduleType": 5, "operateType": "acChgCfg",
-                                               "params": {"chgWatts": int(value), "chgPauseFlag": 255}})
-
+            MaxBatteryLevelEntity(
+                client,
+                self,
+                "bms_emsStatus.maxChargeSoc",
+                const.MAX_CHARGE_LEVEL,
+                50,
+                100,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "upsConfig",
+                    "params": {"maxChgSoc": int(value)},
+                },
+            ),
+            MinBatteryLevelEntity(
+                client,
+                self,
+                "bms_emsStatus.minDsgSoc",
+                const.MIN_DISCHARGE_LEVEL,
+                0,
+                30,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "dsgCfg",
+                    "params": {"minDsgSoc": int(value)},
+                },
+            ),
+            BatteryBackupLevel(
+                client,
+                self,
+                "pd.bpPowerSoc",
+                const.BACKUP_RESERVE_LEVEL,
+                5,
+                100,
+                "bms_emsStatus.minDsgSoc",
+                "bms_emsStatus.maxChargeSoc",
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "watthConfig",
+                    "params": {
+                        "isConfig": 1,
+                        "bpPowerSoc": int(value),
+                        "minDsgSoc": 0,
+                        "minChgSoc": 0,
+                    },
+                },
+            ),
+            MinGenStartLevelEntity(
+                client,
+                self,
+                "bms_emsStatus.minOpenOilEb",
+                const.GEN_AUTO_START_LEVEL,
+                0,
+                30,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "openOilSoc",
+                    "params": {"openOilSoc": value},
+                },
+            ),
+            MaxGenStopLevelEntity(
+                client,
+                self,
+                "bms_emsStatus.maxCloseOilEb",
+                const.GEN_AUTO_STOP_LEVEL,
+                50,
+                100,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "closeOilSoc",
+                    "params": {"closeOilSoc": value},
+                },
+            ),
+            ChargingPowerEntity(
+                client,
+                self,
+                "mppt.cfgChgWatts",
+                const.AC_CHARGING_POWER,
+                200,
+                1200,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "acChgCfg",
+                    "params": {"chgWatts": int(value), "chgPauseFlag": 255},
+                },
+            ),
         ]
 
     def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
         return [
-            BeeperEntity(client, self, "mppt.beepState", const.BEEPER,
-                         lambda value: {"moduleType": 5, "operateType": "quietMode", "params": {"enabled": value}}),
-
-            EnabledEntity(client, self, "pd.dcOutState", const.USB_ENABLED,
-                          lambda value: {"moduleType": 1, "operateType": "dcOutCfg", "params": {"enabled": value}}),
-
-            EnabledEntity(client, self, "pd.acAutoOutConfig", const.AC_ALWAYS_ENABLED,
-                          lambda value, params: {"moduleType": 1, "operateType": "acAutoOutConfig",
-                                                 "params": {"acAutoOutConfig": value,
-                                                            "minAcOutSoc": int(
-                                                                params.get("bms_emsStatus.minDsgSoc", 0)) + 5}}),
-
-            EnabledEntity(client, self, "pd.pvChgPrioSet", const.PV_PRIO,
-                          lambda value: {"moduleType": 1, "operateType": "pvChangePrio",
-                                         "params": {"pvChangeSet": value}}),
-
-            EnabledEntity(client, self, "mppt.cfgAcEnabled", const.AC_ENABLED,
-                          lambda value: {"moduleType": 5, "operateType": "acOutCfg",
-                                         "params": {"enabled": value, "out_voltage": -1, "out_freq": 255,
-                                                    "xboost": 255}}),
-
-            EnabledEntity(client, self, "mppt.cfgAcXboost", const.XBOOST_ENABLED,
-                          lambda value: {"moduleType": 5, "operateType": "acOutCfg",
-                                         "params": {"enabled": 255, "out_voltage": -1, "out_freq": 255,
-                                                    "xboost": value}}),
-
-            EnabledEntity(client, self, "pd.carState", const.DC_ENABLED,
-                          lambda value: {"moduleType": 5, "operateType": "mpptCar", "params": {"enabled": value}}),
-
-            EnabledEntity(client, self, "pd.watchIsConfig", const.BP_ENABLED,
-                          lambda value: {"moduleType": 1,
-                                         "operateType": "watthConfig",
-                                         "params": {"bpPowerSoc": value * 50,
-                                                    "minChgSoc": 0,
-                                                    "isConfig": value,
-                                                    "minDsgSoc": 0}}),
+            BeeperEntity(
+                client,
+                self,
+                "mppt.beepState",
+                const.BEEPER,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "quietMode",
+                    "params": {"enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.dcOutState",
+                const.USB_ENABLED,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "dcOutCfg",
+                    "params": {"enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.acAutoOutConfig",
+                const.AC_ALWAYS_ENABLED,
+                lambda value, params: {
+                    "moduleType": 1,
+                    "operateType": "acAutoOutConfig",
+                    "params": {
+                        "acAutoOutConfig": value,
+                        "minAcOutSoc": int(params.get("bms_emsStatus.minDsgSoc", 0))
+                        + 5,
+                    },
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.pvChgPrioSet",
+                const.PV_PRIO,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "pvChangePrio",
+                    "params": {"pvChangeSet": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "mppt.cfgAcEnabled",
+                const.AC_ENABLED,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "acOutCfg",
+                    "params": {
+                        "enabled": value,
+                        "out_voltage": -1,
+                        "out_freq": 255,
+                        "xboost": 255,
+                    },
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "mppt.cfgAcXboost",
+                const.XBOOST_ENABLED,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "acOutCfg",
+                    "params": {
+                        "enabled": 255,
+                        "out_voltage": -1,
+                        "out_freq": 255,
+                        "xboost": value,
+                    },
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.carState",
+                const.DC_ENABLED,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "mpptCar",
+                    "params": {"enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.watchIsConfig",
+                const.BP_ENABLED,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "watthConfig",
+                    "params": {
+                        "bpPowerSoc": value * 50,
+                        "minChgSoc": 0,
+                        "isConfig": value,
+                        "minDsgSoc": 0,
+                    },
+                },
+            ),
         ]
 
     def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:
         return [
-            DictSelectEntity(client, self, "mppt.dcChgCurrent", const.DC_CHARGE_CURRENT, const.DC_CHARGE_CURRENT_OPTIONS,
-                             lambda value: {"moduleType": 5, "operateType": "dcChgCfg",
-                                            "params": {"dcChgCfg": value}}),
-
-            TimeoutDictSelectEntity(client, self, "pd.lcdOffSec", const.SCREEN_TIMEOUT, const.SCREEN_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 1, "operateType": "lcdCfg",
-                                                   "params": {"brighLevel": 255, "delayOff": value}}),
-
-            TimeoutDictSelectEntity(client, self, "pd.standbyMin", const.UNIT_TIMEOUT, const.UNIT_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 1, "operateType": "standbyTime",
-                                                   "params": {"standbyMin": value}}),
-
-            TimeoutDictSelectEntity(client, self, "mppt.acStandbyMins", const.AC_TIMEOUT, const.AC_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 5, "operateType": "standbyTime",
-                                                   "params": {"standbyMins": value}}),
-
-            TimeoutDictSelectEntity(client, self, "mppt.carStandbyMin", const.DC_TIMEOUT, const.DC_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 5, "operateType": "carStandby",
-                                                   "params": {"standbyMins": value}})
-
+            DictSelectEntity(
+                client,
+                self,
+                "mppt.dcChgCurrent",
+                const.DC_CHARGE_CURRENT,
+                const.DC_CHARGE_CURRENT_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "dcChgCfg",
+                    "params": {"dcChgCfg": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "pd.lcdOffSec",
+                const.SCREEN_TIMEOUT,
+                const.SCREEN_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "lcdCfg",
+                    "params": {"brighLevel": 255, "delayOff": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "pd.standbyMin",
+                const.UNIT_TIMEOUT,
+                const.UNIT_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "standbyTime",
+                    "params": {"standbyMin": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "mppt.acStandbyMins",
+                const.AC_TIMEOUT,
+                const.AC_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "standbyTime",
+                    "params": {"standbyMins": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "mppt.carStandbyMin",
+                const.DC_TIMEOUT,
+                const.DC_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "carStandby",
+                    "params": {"standbyMins": value},
+                },
+            ),
         ]
 
     def _status_sensor(self, client: EcoflowApiClient) -> StatusSensorEntity:

--- a/custom_components/ecoflow_cloud/devices/internal/delta2_max.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta2_max.py
@@ -1,246 +1,703 @@
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import const, BaseDevice
-from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, \
-    BaseSelectEntity
-from custom_components.ecoflow_cloud.number import ChargingPowerEntity, MinBatteryLevelEntity, MaxBatteryLevelEntity, \
-    MaxGenStopLevelEntity, MinGenStartLevelEntity, BatteryBackupLevel
+from custom_components.ecoflow_cloud.entities import (
+    BaseSensorEntity,
+    BaseNumberEntity,
+    BaseSwitchEntity,
+    BaseSelectEntity,
+)
+from custom_components.ecoflow_cloud.number import (
+    ChargingPowerEntity,
+    MinBatteryLevelEntity,
+    MaxBatteryLevelEntity,
+    MaxGenStopLevelEntity,
+    MinGenStartLevelEntity,
+    BatteryBackupLevel,
+)
 from custom_components.ecoflow_cloud.select import TimeoutDictSelectEntity
-from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, RemainSensorEntity, TempSensorEntity, \
-    CyclesSensorEntity, \
-    InWattsSensorEntity, OutWattsSensorEntity, MilliVoltSensorEntity, InMilliampSensorEntity, \
-    InMilliVoltSensorEntity, OutMilliVoltSensorEntity, CapacitySensorEntity, QuotaStatusSensorEntity, \
-    CumulativeCapacitySensorEntity, EnergySensorEntity, QuotaScheduledStatusSensorEntity
+from custom_components.ecoflow_cloud.sensor import (
+    LevelSensorEntity,
+    RemainSensorEntity,
+    TempSensorEntity,
+    CyclesSensorEntity,
+    InWattsSensorEntity,
+    OutWattsSensorEntity,
+    MilliVoltSensorEntity,
+    InMilliampSensorEntity,
+    InMilliVoltSensorEntity,
+    OutMilliVoltSensorEntity,
+    CapacitySensorEntity,
+    QuotaStatusSensorEntity,
+    CumulativeCapacitySensorEntity,
+    EnergySensorEntity,
+    QuotaScheduledStatusSensorEntity,
+)
 from custom_components.ecoflow_cloud.switch import BeeperEntity, EnabledEntity
 
 
 class Delta2Max(BaseDevice):
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
-            CumulativeCapacitySensorEntity(client, self, "bms_bmsInfo.accuChgCap", const.ACCU_CHARGE_CAP, False),
-            EnergySensorEntity(client, self, "bms_bmsInfo.accuChgEnergy", const.ACCU_CHARGE_ENERGY),
-            CumulativeCapacitySensorEntity(client, self, "bms_bmsInfo.accuDsgCap", const.ACCU_DISCHARGE_CAP, False),
-            EnergySensorEntity(client, self, "bms_bmsInfo.accuDsgEnergy", const.ACCU_DISCHARGE_ENERGY),
-
-            LevelSensorEntity(client, self, "bms_bmsStatus.soc", const.MAIN_BATTERY_LEVEL)
+            CumulativeCapacitySensorEntity(
+                client, self, "bms_bmsInfo.accuChgCap", const.ACCU_CHARGE_CAP, False
+            ),
+            EnergySensorEntity(
+                client, self, "bms_bmsInfo.accuChgEnergy", const.ACCU_CHARGE_ENERGY
+            ),
+            CumulativeCapacitySensorEntity(
+                client, self, "bms_bmsInfo.accuDsgCap", const.ACCU_DISCHARGE_CAP, False
+            ),
+            EnergySensorEntity(
+                client, self, "bms_bmsInfo.accuDsgEnergy", const.ACCU_DISCHARGE_ENERGY
+            ),
+            LevelSensorEntity(
+                client, self, "bms_bmsStatus.soc", const.MAIN_BATTERY_LEVEL
+            )
             .attr("bms_bmsStatus.designCap", const.ATTR_DESIGN_CAPACITY, 0)
             .attr("bms_bmsStatus.fullCap", const.ATTR_FULL_CAPACITY, 0)
             .attr("bms_bmsStatus.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.designCap", const.MAIN_DESIGN_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.fullCap", const.MAIN_FULL_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.remainCap", const.MAIN_REMAIN_CAPACITY, False),
-
+            CapacitySensorEntity(
+                client,
+                self,
+                "bms_bmsStatus.designCap",
+                const.MAIN_DESIGN_CAPACITY,
+                False,
+            ),
+            CapacitySensorEntity(
+                client, self, "bms_bmsStatus.fullCap", const.MAIN_FULL_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bms_bmsStatus.remainCap",
+                const.MAIN_REMAIN_CAPACITY,
+                False,
+            ),
             LevelSensorEntity(client, self, "bms_bmsStatus.soh", const.SOH),
-
-            LevelSensorEntity(client, self, "bms_emsStatus.lcdShowSoc", const.COMBINED_BATTERY_LEVEL),
-
+            LevelSensorEntity(
+                client, self, "bms_emsStatus.lcdShowSoc", const.COMBINED_BATTERY_LEVEL
+            ),
             InWattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             OutWattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
-
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
-
             InMilliVoltSensorEntity(client, self, "inv.acInVol", const.AC_IN_VOLT),
             OutMilliVoltSensorEntity(client, self, "inv.invOutVol", const.AC_OUT_VOLT),
-
             InWattsSensorEntity(client, self, "mppt.inWatts", const.SOLAR_1_IN_POWER),
-            InWattsSensorEntity(client, self, "mppt.pv2InWatts", const.SOLAR_2_IN_POWER),
-
-            InMilliVoltSensorEntity(client, self, "mppt.inVol", const.SOLAR_1_IN_VOLTS), 
-            InMilliVoltSensorEntity(client, self, "mppt.pv2InVol", const.SOLAR_2_IN_VOLTS), 
+            InWattsSensorEntity(
+                client, self, "mppt.pv2InWatts", const.SOLAR_2_IN_POWER
+            ),
+            InMilliVoltSensorEntity(client, self, "mppt.inVol", const.SOLAR_1_IN_VOLTS),
+            InMilliVoltSensorEntity(
+                client, self, "mppt.pv2InVol", const.SOLAR_2_IN_VOLTS
+            ),
             InMilliampSensorEntity(client, self, "mppt.inAmp", const.SOLAR_1_IN_AMPS),
-            InMilliampSensorEntity(client, self, "mppt.pv2InAmp", const.SOLAR_2_IN_AMPS),
-
+            InMilliampSensorEntity(
+                client, self, "mppt.pv2InAmp", const.SOLAR_2_IN_AMPS
+            ),
             # OutWattsSensorEntity(client, self, "pd.carWatts", const.DC_OUT_POWER),
             # the same value as pd.carWatts
             OutWattsSensorEntity(client, self, "mppt.outWatts", const.DC_OUT_POWER),
-
-            OutWattsSensorEntity(client, self, "pd.typec1Watts", const.TYPEC_1_OUT_POWER),
-            OutWattsSensorEntity(client, self, "pd.typec2Watts", const.TYPEC_2_OUT_POWER),
-
+            OutWattsSensorEntity(
+                client, self, "pd.typec1Watts", const.TYPEC_1_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "pd.typec2Watts", const.TYPEC_2_OUT_POWER
+            ),
             OutWattsSensorEntity(client, self, "pd.usb1Watts", const.USB_1_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb2Watts", const.USB_2_OUT_POWER),
-
-            OutWattsSensorEntity(client, self, "pd.qcUsb1Watts", const.USB_QC_1_OUT_POWER),
-            OutWattsSensorEntity(client, self, "pd.qcUsb2Watts", const.USB_QC_2_OUT_POWER),
-
-            RemainSensorEntity(client, self, "bms_emsStatus.chgRemainTime", const.CHARGE_REMAINING_TIME),
-            RemainSensorEntity(client, self, "bms_emsStatus.dsgRemainTime", const.DISCHARGE_REMAINING_TIME),
-
+            OutWattsSensorEntity(
+                client, self, "pd.qcUsb1Watts", const.USB_QC_1_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "pd.qcUsb2Watts", const.USB_QC_2_OUT_POWER
+            ),
+            RemainSensorEntity(
+                client, self, "bms_emsStatus.chgRemainTime", const.CHARGE_REMAINING_TIME
+            ),
+            RemainSensorEntity(
+                client,
+                self,
+                "bms_emsStatus.dsgRemainTime",
+                const.DISCHARGE_REMAINING_TIME,
+            ),
             TempSensorEntity(client, self, "inv.outTemp", "Inv Out Temperature"),
             CyclesSensorEntity(client, self, "bms_bmsStatus.cycles", const.CYCLES),
-
             TempSensorEntity(client, self, "bms_bmsStatus.temp", const.BATTERY_TEMP)
             .attr("bms_bmsStatus.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
             .attr("bms_bmsStatus.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            TempSensorEntity(client, self, "bms_bmsStatus.minCellTemp", const.MIN_CELL_TEMP, False),
-            TempSensorEntity(client, self, "bms_bmsStatus.maxCellTemp", const.MAX_CELL_TEMP, False),
-
-            MilliVoltSensorEntity(client, self, "bms_bmsStatus.vol", const.BATTERY_VOLT, False)
+            TempSensorEntity(
+                client, self, "bms_bmsStatus.minCellTemp", const.MIN_CELL_TEMP, False
+            ),
+            TempSensorEntity(
+                client, self, "bms_bmsStatus.maxCellTemp", const.MAX_CELL_TEMP, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bms_bmsStatus.vol", const.BATTERY_VOLT, False
+            )
             .attr("bms_bmsStatus.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
             .attr("bms_bmsStatus.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            MilliVoltSensorEntity(client, self, "bms_bmsStatus.minCellVol", const.MIN_CELL_VOLT, False),
-            MilliVoltSensorEntity(client, self, "bms_bmsStatus.maxCellVol", const.MAX_CELL_VOLT, False),
-            LevelSensorEntity(client, self, "bms_bmsStatus.f32ShowSoc", const.BATTERY_LEVEL_SOC, False, True),
-
+            MilliVoltSensorEntity(
+                client, self, "bms_bmsStatus.minCellVol", const.MIN_CELL_VOLT, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bms_bmsStatus.maxCellVol", const.MAX_CELL_VOLT, False
+            ),
+            LevelSensorEntity(
+                client,
+                self,
+                "bms_bmsStatus.f32ShowSoc",
+                const.BATTERY_LEVEL_SOC,
+                False,
+                True,
+            ),
             # Optional Slave 1 Battery
-            CumulativeCapacitySensorEntity(client, self, "bms_slave_bmsSlaveInfo_1.accuChgCap", const.SLAVE_N_ACCU_CHARGE_CAP % 1, False, True),
-            EnergySensorEntity(client, self, "bms_slave_bmsSlaveInfo_1.accuChgEnergy", const.SLAVE_N_ACCU_CHARGE_ENERGY % 1, False),
-            CumulativeCapacitySensorEntity(client, self, "bms_slave_bmsSlaveInfo_1.accuDsgCap", const.SLAVE_N_ACCU_DISCHARGE_CAP % 1, False, True),
-            EnergySensorEntity(client, self, "bms_slave_bmsSlaveInfo_1.accuDsgEnergy", const.SLAVE_N_ACCU_DISCHARGE_ENERGY % 1, False),
-
-            LevelSensorEntity(client, self, "bms_slave_bmsSlaveStatus_1.soc", const.SLAVE_N_BATTERY_LEVEL % 1, False, True)
+            CumulativeCapacitySensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveInfo_1.accuChgCap",
+                const.SLAVE_N_ACCU_CHARGE_CAP % 1,
+                False,
+                True,
+            ),
+            EnergySensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveInfo_1.accuChgEnergy",
+                const.SLAVE_N_ACCU_CHARGE_ENERGY % 1,
+                False,
+            ),
+            CumulativeCapacitySensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveInfo_1.accuDsgCap",
+                const.SLAVE_N_ACCU_DISCHARGE_CAP % 1,
+                False,
+                True,
+            ),
+            EnergySensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveInfo_1.accuDsgEnergy",
+                const.SLAVE_N_ACCU_DISCHARGE_ENERGY % 1,
+                False,
+            ),
+            LevelSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_1.soc",
+                const.SLAVE_N_BATTERY_LEVEL % 1,
+                False,
+                True,
+            )
             .attr("bms_slave_bmsSlaveStatus_1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
             .attr("bms_slave_bmsSlaveStatus_1.fullCap", const.ATTR_FULL_CAPACITY, 0)
-            .attr("bms_slave_bmsSlaveStatus_1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bms_slave_bmsSlaveStatus_1.designCap", const.SLAVE_N_DESIGN_CAPACITY % 1,False),
-            CapacitySensorEntity(client, self, "bms_slave_bmsSlaveStatus_1.fullCap", const.SLAVE_N_FULL_CAPACITY % 1, False),
-            CapacitySensorEntity(client, self, "bms_slave_bmsSlaveStatus_1.remainCap", const.SLAVE_N_REMAIN_CAPACITY % 1,False),
-
-            TempSensorEntity(client, self, "bms_slave_bmsSlaveStatus_1.temp", const.SLAVE_N_BATTERY_TEMP % 1, False, True)
+            .attr(
+                "bms_slave_bmsSlaveStatus_1.remainCap", const.ATTR_REMAIN_CAPACITY, 0
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_1.designCap",
+                const.SLAVE_N_DESIGN_CAPACITY % 1,
+                False,
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_1.fullCap",
+                const.SLAVE_N_FULL_CAPACITY % 1,
+                False,
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_1.remainCap",
+                const.SLAVE_N_REMAIN_CAPACITY % 1,
+                False,
+            ),
+            TempSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_1.temp",
+                const.SLAVE_N_BATTERY_TEMP % 1,
+                False,
+                True,
+            )
             .attr("bms_slave_bmsSlaveStatus_1.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-            .attr("bms_slave_bmsSlaveStatus_1.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            TempSensorEntity(client, self, "bms_slave_bmsSlaveStatus_1.minCellTemp", const.SLAVE_N_MIN_CELL_TEMP % 1, False),
-            TempSensorEntity(client, self, "bms_slave_bmsSlaveStatus_1.maxCellTemp", const.SLAVE_N_MAX_CELL_TEMP % 1, False),
-
-            MilliVoltSensorEntity(client, self, "bms_slave_bmsSlaveStatus_1.vol", const.SLAVE_N_BATTERY_VOLT % 1, False)
+            .attr(
+                "bms_slave_bmsSlaveStatus_1.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0
+            ),
+            TempSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_1.minCellTemp",
+                const.SLAVE_N_MIN_CELL_TEMP % 1,
+                False,
+            ),
+            TempSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_1.maxCellTemp",
+                const.SLAVE_N_MAX_CELL_TEMP % 1,
+                False,
+            ),
+            MilliVoltSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_1.vol",
+                const.SLAVE_N_BATTERY_VOLT % 1,
+                False,
+            )
             .attr("bms_slave_bmsSlaveStatus_1.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
             .attr("bms_slave_bmsSlaveStatus_1.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            MilliVoltSensorEntity(client, self, "bms_slave_bmsSlaveStatus_1.minCellVol", const.SLAVE_N_MIN_CELL_VOLT % 1,False),
-            MilliVoltSensorEntity(client, self, "bms_slave_bmsSlaveStatus_1.maxCellVol", const.SLAVE_N_MAX_CELL_VOLT % 1,False),
-
-            CyclesSensorEntity(client, self, "bms_slave_bmsSlaveStatus_1.cycles", const.SLAVE_N_CYCLES % 1, False, True),
-            LevelSensorEntity(client, self, "bms_slave_bmsSlaveStatus_1.soh", const.SLAVE_N_SOH % 1, False, True),
-            InWattsSensorEntity(client, self, "bms_slave_bmsSlaveStatus_1.inputWatts", const.SLAVE_N_IN_POWER % 1, False,True),
-            OutWattsSensorEntity(client, self, "bms_slave_bmsSlaveStatus_1.outputWatts", const.SLAVE_N_OUT_POWER % 1, False,True),
-            LevelSensorEntity(client, self, "bms_slave_bmsSlaveStatus_1.f32ShowSoc", const.SLAVE_N_BATTERY_LEVEL_SOC % 1, False, True),
-
+            MilliVoltSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_1.minCellVol",
+                const.SLAVE_N_MIN_CELL_VOLT % 1,
+                False,
+            ),
+            MilliVoltSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_1.maxCellVol",
+                const.SLAVE_N_MAX_CELL_VOLT % 1,
+                False,
+            ),
+            CyclesSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_1.cycles",
+                const.SLAVE_N_CYCLES % 1,
+                False,
+                True,
+            ),
+            LevelSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_1.soh",
+                const.SLAVE_N_SOH % 1,
+                False,
+                True,
+            ),
+            InWattsSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_1.inputWatts",
+                const.SLAVE_N_IN_POWER % 1,
+                False,
+                True,
+            ),
+            OutWattsSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_1.outputWatts",
+                const.SLAVE_N_OUT_POWER % 1,
+                False,
+                True,
+            ),
+            LevelSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_1.f32ShowSoc",
+                const.SLAVE_N_BATTERY_LEVEL_SOC % 1,
+                False,
+                True,
+            ),
             # Optional Slave 2 Battery
-            CumulativeCapacitySensorEntity(client, self, "bms_slave_bmsSlaveInfo_2.accuChgCap", const.SLAVE_N_ACCU_CHARGE_CAP % 2, False),
-            EnergySensorEntity(client, self, "bms_slave_bmsSlaveInfo_2.accuChgEnergy", const.SLAVE_N_ACCU_CHARGE_ENERGY % 2, False, True),
-            CumulativeCapacitySensorEntity(client, self, "bms_slave_bmsSlaveInfo_2.accuDsgCap", const.SLAVE_N_ACCU_DISCHARGE_CAP % 2, False),
-            EnergySensorEntity(client, self, "bms_slave_bmsSlaveInfo_2.accuDsgEnergy", const.SLAVE_N_ACCU_DISCHARGE_ENERGY % 2, False, True),
-
-            LevelSensorEntity(client, self, "bms_slave_bmsSlaveStatus_2.soc", const.SLAVE_N_BATTERY_LEVEL % 2, False, True)
+            CumulativeCapacitySensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveInfo_2.accuChgCap",
+                const.SLAVE_N_ACCU_CHARGE_CAP % 2,
+                False,
+            ),
+            EnergySensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveInfo_2.accuChgEnergy",
+                const.SLAVE_N_ACCU_CHARGE_ENERGY % 2,
+                False,
+                True,
+            ),
+            CumulativeCapacitySensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveInfo_2.accuDsgCap",
+                const.SLAVE_N_ACCU_DISCHARGE_CAP % 2,
+                False,
+            ),
+            EnergySensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveInfo_2.accuDsgEnergy",
+                const.SLAVE_N_ACCU_DISCHARGE_ENERGY % 2,
+                False,
+                True,
+            ),
+            LevelSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_2.soc",
+                const.SLAVE_N_BATTERY_LEVEL % 2,
+                False,
+                True,
+            )
             .attr("bms_slave_bmsSlaveStatus_2.designCap", const.ATTR_DESIGN_CAPACITY, 0)
             .attr("bms_slave_bmsSlaveStatus_2.fullCap", const.ATTR_FULL_CAPACITY, 0)
-            .attr("bms_slave_bmsSlaveStatus_2.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bms_slave_bmsSlaveStatus_2.designCap", const.SLAVE_N_DESIGN_CAPACITY % 2,False),
-            CapacitySensorEntity(client, self, "bms_slave_bmsSlaveStatus_2.fullCap", const.SLAVE_N_FULL_CAPACITY % 2, False),
-            CapacitySensorEntity(client, self, "bms_slave_bmsSlaveStatus_2.remainCap", const.SLAVE_N_REMAIN_CAPACITY % 2,False),
-
-            TempSensorEntity(client, self, "bms_slave_bmsSlaveStatus_2.temp", const.SLAVE_N_BATTERY_TEMP % 2, False, True)
+            .attr(
+                "bms_slave_bmsSlaveStatus_2.remainCap", const.ATTR_REMAIN_CAPACITY, 0
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_2.designCap",
+                const.SLAVE_N_DESIGN_CAPACITY % 2,
+                False,
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_2.fullCap",
+                const.SLAVE_N_FULL_CAPACITY % 2,
+                False,
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_2.remainCap",
+                const.SLAVE_N_REMAIN_CAPACITY % 2,
+                False,
+            ),
+            TempSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_2.temp",
+                const.SLAVE_N_BATTERY_TEMP % 2,
+                False,
+                True,
+            )
             .attr("bms_slave_bmsSlaveStatus_2.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-            .attr("bms_slave_bmsSlaveStatus_2.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            TempSensorEntity(client, self, "bms_slave_bmsSlaveStatus_2.minCellTemp", const.SLAVE_N_MIN_CELL_TEMP % 2, False),
-            TempSensorEntity(client, self, "bms_slave_bmsSlaveStatus_2.maxCellTemp", const.SLAVE_N_MAX_CELL_TEMP % 2, False),
-
-            MilliVoltSensorEntity(client, self, "bms_slave_bmsSlaveStatus_2.vol", const.SLAVE_N_BATTERY_VOLT % 2, False)
+            .attr(
+                "bms_slave_bmsSlaveStatus_2.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0
+            ),
+            TempSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_2.minCellTemp",
+                const.SLAVE_N_MIN_CELL_TEMP % 2,
+                False,
+            ),
+            TempSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_2.maxCellTemp",
+                const.SLAVE_N_MAX_CELL_TEMP % 2,
+                False,
+            ),
+            MilliVoltSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_2.vol",
+                const.SLAVE_N_BATTERY_VOLT % 2,
+                False,
+            )
             .attr("bms_slave_bmsSlaveStatus_2.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
             .attr("bms_slave_bmsSlaveStatus_2.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            MilliVoltSensorEntity(client, self, "bms_slave_bmsSlaveStatus_2.minCellVol", const.SLAVE_N_MIN_CELL_VOLT % 2, False),
-            MilliVoltSensorEntity(client, self, "bms_slave_bmsSlaveStatus_2.maxCellVol", const.SLAVE_N_MAX_CELL_VOLT % 2, False),
-
-            CyclesSensorEntity(client, self, "bms_slave_bmsSlaveStatus_2.cycles", const.SLAVE_N_CYCLES % 2, False, True),
-            LevelSensorEntity(client, self, "bms_slave_bmsSlaveStatus_2.soh", const.SLAVE_N_SOH % 2, False, True),
-            InWattsSensorEntity(client, self, "bms_slave_bmsSlaveStatus_2.inputWatts", const.SLAVE_N_IN_POWER % 2, False, True),
-            OutWattsSensorEntity(client, self, "bms_slave_bmsaSlaveStatus_2.outputWatts", const.SLAVE_N_OUT_POWER % 2, False, True),
-            LevelSensorEntity(client, self, "bms_slave_bmsSlaveStatus_2.f32ShowSoc", const.SLAVE_N_BATTERY_LEVEL_SOC % 2, False, True),
-
-                       
+            MilliVoltSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_2.minCellVol",
+                const.SLAVE_N_MIN_CELL_VOLT % 2,
+                False,
+            ),
+            MilliVoltSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_2.maxCellVol",
+                const.SLAVE_N_MAX_CELL_VOLT % 2,
+                False,
+            ),
+            CyclesSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_2.cycles",
+                const.SLAVE_N_CYCLES % 2,
+                False,
+                True,
+            ),
+            LevelSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_2.soh",
+                const.SLAVE_N_SOH % 2,
+                False,
+                True,
+            ),
+            InWattsSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_2.inputWatts",
+                const.SLAVE_N_IN_POWER % 2,
+                False,
+                True,
+            ),
+            OutWattsSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsaSlaveStatus_2.outputWatts",
+                const.SLAVE_N_OUT_POWER % 2,
+                False,
+                True,
+            ),
+            LevelSensorEntity(
+                client,
+                self,
+                "bms_slave_bmsSlaveStatus_2.f32ShowSoc",
+                const.SLAVE_N_BATTERY_LEVEL_SOC % 2,
+                False,
+                True,
+            ),
             QuotaStatusSensorEntity(client, self),
-            QuotaScheduledStatusSensorEntity(client, self, (60*60)) # reload every 1h
+            QuotaScheduledStatusSensorEntity(
+                client, self, (60 * 60)
+            ),  # reload every 1h
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return [
-            MaxBatteryLevelEntity(client, self, "bms_emsStatus.maxChargeSoc", const.MAX_CHARGE_LEVEL, 50, 100,
-                                  lambda value: {"moduleType": 2, "operateType": "upsConfig",
-                                                 "moduleSn": self.device_info.sn,
-                                                 "params": {"maxChgSoc": int(value)}}),
-
-            MinBatteryLevelEntity(client, self, "bms_emsStatus.minDsgSoc", const.MIN_DISCHARGE_LEVEL, 0, 30,
-                                  lambda value: {"moduleType": 2, "operateType": "dsgCfg",
-                                                 "moduleSn": self.device_info.sn,
-                                                 "params": {"minDsgSoc": int(value)}}),
-
-            BatteryBackupLevel(client, self, "pd.bpPowerSoc", const.BACKUP_RESERVE_LEVEL, 5, 100,
-                               "bms_emsStatus.minDsgSoc", "bms_emsStatus.maxChargeSoc",
-                               lambda value: {"moduleType": 1, "operateType": "watthConfig",
-                                              "params": {"isConfig": 1, "bpPowerSoc": int(value), "minDsgSoc": 0,
-                                                         "minChgSoc": 0}}),
-
-            MinGenStartLevelEntity(client, self, "bms_emsStatus.minOpenOilEbSoc", const.GEN_AUTO_START_LEVEL, 0, 30,
-                                   lambda value: {"moduleType": 2, "operateType": "openOilSoc",
-                                                  "moduleSn": self.device_info.sn,
-                                                  "params": {"openOilSoc": value}}),
-
-            MaxGenStopLevelEntity(client, self, "bms_emsStatus.maxCloseOilEbSoc", const.GEN_AUTO_STOP_LEVEL, 50, 100,
-                                  lambda value: {"moduleType": 2, "operateType": "closeOilSoc",
-                                                 "moduleSn": self.device_info.sn,
-                                                 "params": {"closeOilSoc": value}}),
-
-            ChargingPowerEntity(client, self, "inv.SlowChgWatts", const.AC_CHARGING_POWER, 200, 2400,
-                                lambda value: {"moduleType": 3, "operateType": "acChgCfg",
-                                               "moduleSn": self.device_info.sn,
-                                               "params": {"slowChgWatts": int(value), "fastChgWatts": 2000,
-                                                          "chgPauseFlag": 0}})
-
+            MaxBatteryLevelEntity(
+                client,
+                self,
+                "bms_emsStatus.maxChargeSoc",
+                const.MAX_CHARGE_LEVEL,
+                50,
+                100,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "upsConfig",
+                    "moduleSn": self.device_info.sn,
+                    "params": {"maxChgSoc": int(value)},
+                },
+            ),
+            MinBatteryLevelEntity(
+                client,
+                self,
+                "bms_emsStatus.minDsgSoc",
+                const.MIN_DISCHARGE_LEVEL,
+                0,
+                30,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "dsgCfg",
+                    "moduleSn": self.device_info.sn,
+                    "params": {"minDsgSoc": int(value)},
+                },
+            ),
+            BatteryBackupLevel(
+                client,
+                self,
+                "pd.bpPowerSoc",
+                const.BACKUP_RESERVE_LEVEL,
+                5,
+                100,
+                "bms_emsStatus.minDsgSoc",
+                "bms_emsStatus.maxChargeSoc",
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "watthConfig",
+                    "params": {
+                        "isConfig": 1,
+                        "bpPowerSoc": int(value),
+                        "minDsgSoc": 0,
+                        "minChgSoc": 0,
+                    },
+                },
+            ),
+            MinGenStartLevelEntity(
+                client,
+                self,
+                "bms_emsStatus.minOpenOilEbSoc",
+                const.GEN_AUTO_START_LEVEL,
+                0,
+                30,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "openOilSoc",
+                    "moduleSn": self.device_info.sn,
+                    "params": {"openOilSoc": value},
+                },
+            ),
+            MaxGenStopLevelEntity(
+                client,
+                self,
+                "bms_emsStatus.maxCloseOilEbSoc",
+                const.GEN_AUTO_STOP_LEVEL,
+                50,
+                100,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "closeOilSoc",
+                    "moduleSn": self.device_info.sn,
+                    "params": {"closeOilSoc": value},
+                },
+            ),
+            ChargingPowerEntity(
+                client,
+                self,
+                "inv.SlowChgWatts",
+                const.AC_CHARGING_POWER,
+                200,
+                2400,
+                lambda value: {
+                    "moduleType": 3,
+                    "operateType": "acChgCfg",
+                    "moduleSn": self.device_info.sn,
+                    "params": {
+                        "slowChgWatts": int(value),
+                        "fastChgWatts": 2000,
+                        "chgPauseFlag": 0,
+                    },
+                },
+            ),
         ]
 
     def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
         return [
-            BeeperEntity(client, self, "pd.beepMode", const.BEEPER,
-                         lambda value: {"moduleType": 1, "operateType": "quietCfg",
-                                        "moduleSn": self.device_info.sn,
-                                        "params": {"enabled": value}}),
-
-            EnabledEntity(client, self, "pd.dcOutState", const.USB_ENABLED,
-                          lambda value: {"moduleType": 1, "operateType": "dcOutCfg",
-                                         "moduleSn": self.device_info.sn,
-                                         "params": {"enabled": value}}),
-
-            EnabledEntity(client, self, "pd.newAcAutoOnCfg", const.AC_ALWAYS_ENABLED,
-                          lambda value: {"moduleType": 1, "operateType": "newAcAutoOnCfg",
-                                         "moduleSn": self.device_info.sn,
-                                         "params": {"enabled": value, "minAcSoc": 5}}),
-
-            EnabledEntity(client, self, "inv.cfgAcEnabled", const.AC_ENABLED,
-                          lambda value: {"moduleType": 3, "operateType": "acOutCfg",
-                                         "moduleSn": self.device_info.sn,
-                                         "params": {"enabled": value, "out_voltage": -1,
-                                                    "out_freq": 255, "xboost": 255}}),
-
-            EnabledEntity(client, self, "inv.cfgAcXboost", const.XBOOST_ENABLED,
-                          lambda value: {"moduleType": 3, "operateType": "acOutCfg",
-                                         "moduleSn": self.device_info.sn,
-                                         "params": {"xboost": value}}),
-            EnabledEntity(client, self, "pd.carState", const.DC_ENABLED,
-                          lambda value: {"moduleType": 5, "operateType": "mpptCar",
-                                         "params": {"enabled": value}}),
-
-            EnabledEntity(client, self, "pd.watchIsConfig", const.BP_ENABLED,
-                          lambda value: {"moduleType": 1,
-                                         "operateType": "watthConfig",
-                                         "params": {"bpPowerSoc": value * 50,
-                                                    "minChgSoc": 0,
-                                                    "isConfig": value,
-                                                    "minDsgSoc": 0}}),
+            BeeperEntity(
+                client,
+                self,
+                "pd.beepMode",
+                const.BEEPER,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "quietCfg",
+                    "moduleSn": self.device_info.sn,
+                    "params": {"enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.dcOutState",
+                const.USB_ENABLED,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "dcOutCfg",
+                    "moduleSn": self.device_info.sn,
+                    "params": {"enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.newAcAutoOnCfg",
+                const.AC_ALWAYS_ENABLED,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "newAcAutoOnCfg",
+                    "moduleSn": self.device_info.sn,
+                    "params": {"enabled": value, "minAcSoc": 5},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "inv.cfgAcEnabled",
+                const.AC_ENABLED,
+                lambda value: {
+                    "moduleType": 3,
+                    "operateType": "acOutCfg",
+                    "moduleSn": self.device_info.sn,
+                    "params": {
+                        "enabled": value,
+                        "out_voltage": -1,
+                        "out_freq": 255,
+                        "xboost": 255,
+                    },
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "inv.cfgAcXboost",
+                const.XBOOST_ENABLED,
+                lambda value: {
+                    "moduleType": 3,
+                    "operateType": "acOutCfg",
+                    "moduleSn": self.device_info.sn,
+                    "params": {"xboost": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.carState",
+                const.DC_ENABLED,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "mpptCar",
+                    "params": {"enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.watchIsConfig",
+                const.BP_ENABLED,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "watthConfig",
+                    "params": {
+                        "bpPowerSoc": value * 50,
+                        "minChgSoc": 0,
+                        "isConfig": value,
+                        "minDsgSoc": 0,
+                    },
+                },
+            ),
         ]
 
     def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:
         return [
-            TimeoutDictSelectEntity(client, self, "pd.lcdOffSec", const.SCREEN_TIMEOUT, const.SCREEN_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 1, "operateType": "lcdCfg",
-                                                   "moduleSn": self.device_info.sn,
-                                                   "params": {"brighLevel": 255, "delayOff": value}}),
-
-            TimeoutDictSelectEntity(client, self, "inv.standbyMin", const.UNIT_TIMEOUT, const.UNIT_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 1, "operateType": "standbyTime",
-                                                   "moduleSn": self.device_info.sn,
-                                                   "params": {"standbyMin": value}}),
-
-            TimeoutDictSelectEntity(client, self, "mppt.carStandbyMin", const.AC_TIMEOUT, const.AC_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 5, "operateType": "standbyTime",
-                                                   "moduleSn": self.device_info.sn,
-                                                   "params": {"standbyMins": value}}),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "pd.lcdOffSec",
+                const.SCREEN_TIMEOUT,
+                const.SCREEN_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "lcdCfg",
+                    "moduleSn": self.device_info.sn,
+                    "params": {"brighLevel": 255, "delayOff": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "inv.standbyMin",
+                const.UNIT_TIMEOUT,
+                const.UNIT_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "standbyTime",
+                    "moduleSn": self.device_info.sn,
+                    "params": {"standbyMin": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "mppt.carStandbyMin",
+                const.AC_TIMEOUT,
+                const.AC_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "standbyTime",
+                    "moduleSn": self.device_info.sn,
+                    "params": {"standbyMins": value},
+                },
+            ),
         ]

--- a/custom_components/ecoflow_cloud/devices/internal/delta_max.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_max.py
@@ -1,15 +1,41 @@
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import const, BaseDevice
-from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, BaseSelectEntity
-from custom_components.ecoflow_cloud.number import ChargingPowerEntity, MinBatteryLevelEntity, MaxBatteryLevelEntity, \
-    MaxGenStopLevelEntity, MinGenStartLevelEntity
-from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, TempSensorEntity, \
-    CyclesSensorEntity, \
-    InWattsSensorEntity, OutWattsSensorEntity, MilliVoltSensorEntity, \
-    InMilliVoltSensorEntity, OutMilliVoltSensorEntity, CapacitySensorEntity, InWattsSolarSensorEntity, \
-    InEnergySensorEntity, OutEnergySensorEntity, OutWattsDcSensorEntity, QuotaStatusSensorEntity, \
-    StatusSensorEntity, \
-    MilliampSensorEntity, InVoltSolarSensorEntity, InMilliampSolarSensorEntity, OutVoltDcSensorEntity
+from custom_components.ecoflow_cloud.entities import (
+    BaseSensorEntity,
+    BaseNumberEntity,
+    BaseSwitchEntity,
+    BaseSelectEntity,
+)
+from custom_components.ecoflow_cloud.number import (
+    ChargingPowerEntity,
+    MinBatteryLevelEntity,
+    MaxBatteryLevelEntity,
+    MaxGenStopLevelEntity,
+    MinGenStartLevelEntity,
+)
+from custom_components.ecoflow_cloud.sensor import (
+    LevelSensorEntity,
+    WattsSensorEntity,
+    RemainSensorEntity,
+    TempSensorEntity,
+    CyclesSensorEntity,
+    InWattsSensorEntity,
+    OutWattsSensorEntity,
+    MilliVoltSensorEntity,
+    InMilliVoltSensorEntity,
+    OutMilliVoltSensorEntity,
+    CapacitySensorEntity,
+    InWattsSolarSensorEntity,
+    InEnergySensorEntity,
+    OutEnergySensorEntity,
+    OutWattsDcSensorEntity,
+    QuotaStatusSensorEntity,
+    StatusSensorEntity,
+    MilliampSensorEntity,
+    InVoltSolarSensorEntity,
+    InMilliampSolarSensorEntity,
+    OutVoltDcSensorEntity,
+)
 from custom_components.ecoflow_cloud.switch import BeeperEntity, EnabledEntity
 
 
@@ -17,193 +43,466 @@ class DeltaMax(BaseDevice):
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
             LevelSensorEntity(client, self, "bmsMaster.soc", const.MAIN_BATTERY_LEVEL)
-                .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            LevelSensorEntity(client, self, "bmsMaster.f32ShowSoc", const.MAIN_BATTERY_LEVEL_F32, False)
-                .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bmsMaster.designCap", const.MAIN_DESIGN_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bmsMaster.fullCap", const.MAIN_FULL_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bmsMaster.remainCap", const.MAIN_REMAIN_CAPACITY, False),
-
+            .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            LevelSensorEntity(
+                client,
+                self,
+                "bmsMaster.f32ShowSoc",
+                const.MAIN_BATTERY_LEVEL_F32,
+                False,
+            )
+            .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            CapacitySensorEntity(
+                client, self, "bmsMaster.designCap", const.MAIN_DESIGN_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bmsMaster.fullCap", const.MAIN_FULL_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bmsMaster.remainCap", const.MAIN_REMAIN_CAPACITY, False
+            ),
             LevelSensorEntity(client, self, "bmsMaster.soh", const.SOH),
-
-            LevelSensorEntity(client, self, "ems.lcdShowSoc", const.COMBINED_BATTERY_LEVEL),
-            LevelSensorEntity(client, self, "ems.f32LcdShowSoc", const.COMBINED_BATTERY_LEVEL_F32, False),
+            LevelSensorEntity(
+                client, self, "ems.lcdShowSoc", const.COMBINED_BATTERY_LEVEL
+            ),
+            LevelSensorEntity(
+                client,
+                self,
+                "ems.f32LcdShowSoc",
+                const.COMBINED_BATTERY_LEVEL_F32,
+                False,
+            ),
             InWattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             OutWattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
-            MilliampSensorEntity(client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT),
-
+            MilliampSensorEntity(
+                client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT
+            ),
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
-
             InMilliVoltSensorEntity(client, self, "inv.acInVol", const.AC_IN_VOLT),
             OutMilliVoltSensorEntity(client, self, "inv.invOutVol", const.AC_OUT_VOLT),
-
-            InWattsSolarSensorEntity(client, self, "mppt.inWatts", const.SOLAR_IN_POWER),
+            InWattsSolarSensorEntity(
+                client, self, "mppt.inWatts", const.SOLAR_IN_POWER
+            ),
             InVoltSolarSensorEntity(client, self, "mppt.inVol", const.SOLAR_IN_VOLTAGE),
-            InMilliampSolarSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT),
-
+            InMilliampSolarSensorEntity(
+                client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT
+            ),
             OutWattsDcSensorEntity(client, self, "mppt.outWatts", const.DC_OUT_POWER),
             OutVoltDcSensorEntity(client, self, "mppt.outVol", const.DC_OUT_VOLTAGE),
-
-            OutWattsSensorEntity(client, self, "pd.typec1Watts", const.TYPEC_1_OUT_POWER),
-            OutWattsSensorEntity(client, self, "pd.typec2Watts", const.TYPEC_2_OUT_POWER),
-
+            OutWattsSensorEntity(
+                client, self, "pd.typec1Watts", const.TYPEC_1_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "pd.typec2Watts", const.TYPEC_2_OUT_POWER
+            ),
             OutWattsSensorEntity(client, self, "pd.usb1Watts", const.USB_1_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb2Watts", const.USB_2_OUT_POWER),
-
-            OutWattsSensorEntity(client, self, "pd.qcUsb1Watts", const.USB_QC_1_OUT_POWER),
-            OutWattsSensorEntity(client, self, "pd.qcUsb2Watts", const.USB_QC_2_OUT_POWER),
-
-            RemainSensorEntity(client, self, "ems.chgRemainTime", const.CHARGE_REMAINING_TIME),
-            RemainSensorEntity(client, self, "ems.dsgRemainTime", const.DISCHARGE_REMAINING_TIME),
-
+            OutWattsSensorEntity(
+                client, self, "pd.qcUsb1Watts", const.USB_QC_1_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "pd.qcUsb2Watts", const.USB_QC_2_OUT_POWER
+            ),
+            RemainSensorEntity(
+                client, self, "ems.chgRemainTime", const.CHARGE_REMAINING_TIME
+            ),
+            RemainSensorEntity(
+                client, self, "ems.dsgRemainTime", const.DISCHARGE_REMAINING_TIME
+            ),
             TempSensorEntity(client, self, "inv.outTemp", "Inv Out Temperature"),
             CyclesSensorEntity(client, self, "bmsMaster.cycles", const.CYCLES),
-
             TempSensorEntity(client, self, "bmsMaster.temp", const.BATTERY_TEMP)
-                .attr("bmsMaster.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-                .attr("bmsMaster.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            TempSensorEntity(client, self, "bmsMaster.minCellTemp", const.MIN_CELL_TEMP, False),
-            TempSensorEntity(client, self, "bmsMaster.maxCellTemp", const.MAX_CELL_TEMP, False),
-
-            MilliVoltSensorEntity(client, self, "bmsMaster.vol", const.BATTERY_VOLT, False)
-                .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
-                .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            MilliVoltSensorEntity(client, self, "bmsMaster.minCellVol", const.MIN_CELL_VOLT, False),
-            MilliVoltSensorEntity(client, self, "bmsMaster.maxCellVol", const.MAX_CELL_VOLT, False),
-
+            .attr("bmsMaster.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+            .attr("bmsMaster.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+            TempSensorEntity(
+                client, self, "bmsMaster.minCellTemp", const.MIN_CELL_TEMP, False
+            ),
+            TempSensorEntity(
+                client, self, "bmsMaster.maxCellTemp", const.MAX_CELL_TEMP, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bmsMaster.vol", const.BATTERY_VOLT, False
+            )
+            .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
+            .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
+            MilliVoltSensorEntity(
+                client, self, "bmsMaster.minCellVol", const.MIN_CELL_VOLT, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bmsMaster.maxCellVol", const.MAX_CELL_VOLT, False
+            ),
             # https://github.com/tolwi/hassio-ecoflow-cloud/discussions/87
             InEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
             InEnergySensorEntity(client, self, "pd.chgPowerAc", const.CHARGE_AC_ENERGY),
             InEnergySensorEntity(client, self, "pd.chgPowerDc", const.CHARGE_DC_ENERGY),
-            OutEnergySensorEntity(client, self, "pd.dsgPowerAc", const.DISCHARGE_AC_ENERGY),
-            OutEnergySensorEntity(client, self, "pd.dsgPowerDc", const.DISCHARGE_DC_ENERGY),
-
+            OutEnergySensorEntity(
+                client, self, "pd.dsgPowerAc", const.DISCHARGE_AC_ENERGY
+            ),
+            OutEnergySensorEntity(
+                client, self, "pd.dsgPowerDc", const.DISCHARGE_DC_ENERGY
+            ),
             # Optional Slave Batteries
-            LevelSensorEntity(client, self, "bmsSlave1.soc", const.SLAVE_N_BATTERY_LEVEL % 1, False, True)
-                .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            LevelSensorEntity(client, self, "bmsSlave1.f32ShowSoc", const.SLAVE_N_BATTERY_LEVEL_F32 % 1, False, False)
-                .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bmsSlave1.designCap", const.SLAVE_N_DESIGN_CAPACITY % 1, False),
-            CapacitySensorEntity(client, self, "bmsSlave1.fullCap", const.SLAVE_N_FULL_CAPACITY % 1, False),
-            CapacitySensorEntity(client, self, "bmsSlave1.remainCap", const.SLAVE_N_REMAIN_CAPACITY % 1, False),
+            LevelSensorEntity(
+                client,
+                self,
+                "bmsSlave1.soc",
+                const.SLAVE_N_BATTERY_LEVEL % 1,
+                False,
+                True,
+            )
+            .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            LevelSensorEntity(
+                client,
+                self,
+                "bmsSlave1.f32ShowSoc",
+                const.SLAVE_N_BATTERY_LEVEL_F32 % 1,
+                False,
+                False,
+            )
+            .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bmsSlave1.designCap",
+                const.SLAVE_N_DESIGN_CAPACITY % 1,
+                False,
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bmsSlave1.fullCap",
+                const.SLAVE_N_FULL_CAPACITY % 1,
+                False,
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bmsSlave1.remainCap",
+                const.SLAVE_N_REMAIN_CAPACITY % 1,
+                False,
+            ),
             LevelSensorEntity(client, self, "bmsSlave1.soh", const.SLAVE_N_SOH % 1),
-
-            TempSensorEntity(client, self, "bmsSlave1.temp", const.SLAVE_N_BATTERY_TEMP % 1, False, True)
+            TempSensorEntity(
+                client,
+                self,
+                "bmsSlave1.temp",
+                const.SLAVE_N_BATTERY_TEMP % 1,
+                False,
+                True,
+            )
             .attr("bmsSlave1.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
             .attr("bmsSlave1.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            WattsSensorEntity(client, self, "bmsSlave1.inputWatts", const.SLAVE_N_IN_POWER % 1, False, True),
-            WattsSensorEntity(client, self, "bmsSlave1.outputWatts", const.SLAVE_N_OUT_POWER % 1, False, True),
-
-            LevelSensorEntity(client, self, "bmsSlave2.soc", const.SLAVE_N_BATTERY_LEVEL % 2, False, True)
-                .attr("bmsSlave2.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsSlave2.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsSlave2.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            LevelSensorEntity(client, self, "bmsSlave2.f32ShowSoc", const.SLAVE_N_BATTERY_LEVEL_F32 % 2, False, False)
-                .attr("bmsSlave2.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsSlave2.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsSlave2.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bmsSlave2.designCap", const.SLAVE_N_DESIGN_CAPACITY % 2, False),
-            CapacitySensorEntity(client, self, "bmsSlave2.fullCap", const.SLAVE_N_FULL_CAPACITY % 2, False),
-            CapacitySensorEntity(client, self, "bmsSlave2.remainCap", const.SLAVE_N_REMAIN_CAPACITY % 2, False),
+            WattsSensorEntity(
+                client,
+                self,
+                "bmsSlave1.inputWatts",
+                const.SLAVE_N_IN_POWER % 1,
+                False,
+                True,
+            ),
+            WattsSensorEntity(
+                client,
+                self,
+                "bmsSlave1.outputWatts",
+                const.SLAVE_N_OUT_POWER % 1,
+                False,
+                True,
+            ),
+            LevelSensorEntity(
+                client,
+                self,
+                "bmsSlave2.soc",
+                const.SLAVE_N_BATTERY_LEVEL % 2,
+                False,
+                True,
+            )
+            .attr("bmsSlave2.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsSlave2.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsSlave2.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            LevelSensorEntity(
+                client,
+                self,
+                "bmsSlave2.f32ShowSoc",
+                const.SLAVE_N_BATTERY_LEVEL_F32 % 2,
+                False,
+                False,
+            )
+            .attr("bmsSlave2.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsSlave2.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsSlave2.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bmsSlave2.designCap",
+                const.SLAVE_N_DESIGN_CAPACITY % 2,
+                False,
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bmsSlave2.fullCap",
+                const.SLAVE_N_FULL_CAPACITY % 2,
+                False,
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bmsSlave2.remainCap",
+                const.SLAVE_N_REMAIN_CAPACITY % 2,
+                False,
+            ),
             LevelSensorEntity(client, self, "bmsSlave2.soh", const.SLAVE_N_SOH % 2),
-            MilliVoltSensorEntity(client, self, "bmsSlave1.vol", const.SLAVE_N_BATTERY_VOLT % 1, False),
-            MilliVoltSensorEntity(client, self, "bmsSlave1.minCellVol", const.SLAVE_N_MIN_CELL_VOLT % 1, False),
-            MilliVoltSensorEntity(client, self, "bmsSlave1.maxCellVol", const.SLAVE_N_MAX_CELL_VOLT % 1, False),
-            MilliampSensorEntity(client, self, "bmsSlave1.amp", const.SLAVE_N_BATTERY_CURRENT % 1, False),
-            MilliVoltSensorEntity(client, self, "bmsSlave2.vol", const.SLAVE_N_BATTERY_VOLT % 2, False),
-            MilliVoltSensorEntity(client, self, "bmsSlave2.minCellVol", const.SLAVE_N_MIN_CELL_VOLT % 2, False),
-            MilliVoltSensorEntity(client, self, "bmsSlave2.maxCellVol", const.SLAVE_N_MAX_CELL_VOLT % 2, False),
-            MilliampSensorEntity(client, self, "bmsSlave2.amp", const.SLAVE_N_BATTERY_CURRENT % 2, False),
-            TempSensorEntity(client, self, "bmsSlave2.temp", const.SLAVE_N_BATTERY_TEMP % 2, False, True)
-                .attr("bmsSlave2.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-                .attr("bmsSlave2.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            WattsSensorEntity(client, self, "bmsSlave2.inputWatts", const.SLAVE_N_IN_POWER % 2, False, True),
-            WattsSensorEntity(client, self, "bmsSlave2.outputWatts", const.SLAVE_N_OUT_POWER % 2, False, True),
-            CyclesSensorEntity(client, self, "bmsSlave1.cycles", const.SLAVE_N_CYCLES % 1, False),
-            CyclesSensorEntity(client, self, "bmsSlave2.cycles", const.SLAVE_N_CYCLES % 2, False),
-            self._status_sensor(client)
+            MilliVoltSensorEntity(
+                client, self, "bmsSlave1.vol", const.SLAVE_N_BATTERY_VOLT % 1, False
+            ),
+            MilliVoltSensorEntity(
+                client,
+                self,
+                "bmsSlave1.minCellVol",
+                const.SLAVE_N_MIN_CELL_VOLT % 1,
+                False,
+            ),
+            MilliVoltSensorEntity(
+                client,
+                self,
+                "bmsSlave1.maxCellVol",
+                const.SLAVE_N_MAX_CELL_VOLT % 1,
+                False,
+            ),
+            MilliampSensorEntity(
+                client, self, "bmsSlave1.amp", const.SLAVE_N_BATTERY_CURRENT % 1, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bmsSlave2.vol", const.SLAVE_N_BATTERY_VOLT % 2, False
+            ),
+            MilliVoltSensorEntity(
+                client,
+                self,
+                "bmsSlave2.minCellVol",
+                const.SLAVE_N_MIN_CELL_VOLT % 2,
+                False,
+            ),
+            MilliVoltSensorEntity(
+                client,
+                self,
+                "bmsSlave2.maxCellVol",
+                const.SLAVE_N_MAX_CELL_VOLT % 2,
+                False,
+            ),
+            MilliampSensorEntity(
+                client, self, "bmsSlave2.amp", const.SLAVE_N_BATTERY_CURRENT % 2, False
+            ),
+            TempSensorEntity(
+                client,
+                self,
+                "bmsSlave2.temp",
+                const.SLAVE_N_BATTERY_TEMP % 2,
+                False,
+                True,
+            )
+            .attr("bmsSlave2.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+            .attr("bmsSlave2.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+            WattsSensorEntity(
+                client,
+                self,
+                "bmsSlave2.inputWatts",
+                const.SLAVE_N_IN_POWER % 2,
+                False,
+                True,
+            ),
+            WattsSensorEntity(
+                client,
+                self,
+                "bmsSlave2.outputWatts",
+                const.SLAVE_N_OUT_POWER % 2,
+                False,
+                True,
+            ),
+            CyclesSensorEntity(
+                client, self, "bmsSlave1.cycles", const.SLAVE_N_CYCLES % 1, False
+            ),
+            CyclesSensorEntity(
+                client, self, "bmsSlave2.cycles", const.SLAVE_N_CYCLES % 2, False
+            ),
+            self._status_sensor(client),
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return [
-            MaxBatteryLevelEntity(client, self, "ems.maxChargeSoc", const.MAX_CHARGE_LEVEL, 50, 100,
-                                  lambda value: {"moduleType": 2, "operateType": "TCP",
-                                                 "params": {"id": 49, "maxChgSoc": value}}),
-
-            MinBatteryLevelEntity(client, self, "ems.minDsgSoc", const.MIN_DISCHARGE_LEVEL, 0, 30,
-                                  lambda value: {"moduleType": 2, "operateType": "TCP",
-                                                 "params": {"id": 51, "minDsgSoc": value}}),
-
-            MinGenStartLevelEntity(client, self, "ems.minOpenOilEbSoc", const.GEN_AUTO_START_LEVEL, 0, 30,
-                                   lambda value: {"moduleType": 2, "operateType": "TCP",
-                                                  "params": {"id": 52, "openOilSoc": value}}),
-
-            MaxGenStopLevelEntity(client, self, "ems.maxCloseOilEbSoc", const.GEN_AUTO_STOP_LEVEL, 50, 100,
-                                  lambda value: {"moduleType": 2, "operateType": "TCP",
-                                                 "params": {"id": 53, "closeOilSoc": value}}),
-
-            ChargingPowerEntity(client, self, "inv.cfgSlowChgWatts", const.AC_CHARGING_POWER, 100, 2000,
-                                lambda value: {"moduleType": 0, "operateType": "TCP",
-                                               "params": {"slowChgPower": value, "id": 69}}),
-
+            MaxBatteryLevelEntity(
+                client,
+                self,
+                "ems.maxChargeSoc",
+                const.MAX_CHARGE_LEVEL,
+                50,
+                100,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "TCP",
+                    "params": {"id": 49, "maxChgSoc": value},
+                },
+            ),
+            MinBatteryLevelEntity(
+                client,
+                self,
+                "ems.minDsgSoc",
+                const.MIN_DISCHARGE_LEVEL,
+                0,
+                30,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "TCP",
+                    "params": {"id": 51, "minDsgSoc": value},
+                },
+            ),
+            MinGenStartLevelEntity(
+                client,
+                self,
+                "ems.minOpenOilEbSoc",
+                const.GEN_AUTO_START_LEVEL,
+                0,
+                30,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "TCP",
+                    "params": {"id": 52, "openOilSoc": value},
+                },
+            ),
+            MaxGenStopLevelEntity(
+                client,
+                self,
+                "ems.maxCloseOilEbSoc",
+                const.GEN_AUTO_STOP_LEVEL,
+                50,
+                100,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "TCP",
+                    "params": {"id": 53, "closeOilSoc": value},
+                },
+            ),
+            ChargingPowerEntity(
+                client,
+                self,
+                "inv.cfgSlowChgWatts",
+                const.AC_CHARGING_POWER,
+                100,
+                2000,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"slowChgPower": value, "id": 69},
+                },
+            ),
         ]
 
     def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
         return [
-            BeeperEntity(client, self, "pd.beepState", const.BEEPER,
-                         lambda value: {"moduleType": 5, "operateType": "TCP", "params": {"id": 38, "enabled": value}}),
-
-            EnabledEntity(client, self, "pd.dcOutState", const.USB_ENABLED,
-                          lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"enabled": value, "id": 34  }}),
-
-            EnabledEntity(client, self, "pd.acAutoOnCfg", const.AC_ALWAYS_ENABLED,
-                          lambda value: {"moduleType": 1, "operateType": "acAutoOn", "params": {"cfg": value}}),
-
-            EnabledEntity(client, self, "pd.pvChgPrioSet", const.PV_PRIO,
-                          lambda value: {"moduleType": 1, "operateType": "pvChangePrio", "params": {"pvChangeSet": value}}),
-
-            EnabledEntity(client, self, "inv.cfgAcEnabled", const.AC_ENABLED,
-                          lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"enabled": value, "id": 66  }}),
-
-            EnabledEntity(client, self, "inv.cfgAcXboost", const.XBOOST_ENABLED,
-                          lambda value: {"moduleType": 5, "operateType": "TCP", "params": {"id": 66, "xboost": value}}),
-
-            EnabledEntity(client, self, "mppt.carState", const.DC_ENABLED,
-                          lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"enabled": value, "id": 81  }}),
-
+            BeeperEntity(
+                client,
+                self,
+                "pd.beepState",
+                const.BEEPER,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "TCP",
+                    "params": {"id": 38, "enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.dcOutState",
+                const.USB_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"enabled": value, "id": 34},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.acAutoOnCfg",
+                const.AC_ALWAYS_ENABLED,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "acAutoOn",
+                    "params": {"cfg": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.pvChgPrioSet",
+                const.PV_PRIO,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "pvChangePrio",
+                    "params": {"pvChangeSet": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "inv.cfgAcEnabled",
+                const.AC_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"enabled": value, "id": 66},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "inv.cfgAcXboost",
+                const.XBOOST_ENABLED,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "TCP",
+                    "params": {"id": 66, "xboost": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "mppt.carState",
+                const.DC_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"enabled": value, "id": 81},
+                },
+            ),
         ]
 
     def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:
         return [
-            #DictSelectEntity(client, self, "mppt.cfgDcChgCurrent", const.DC_CHARGE_CURRENT, const.DC_CHARGE_CURRENT_OPTIONS,
+            # DictSelectEntity(client, self, "mppt.cfgDcChgCurrent", const.DC_CHARGE_CURRENT, const.DC_CHARGE_CURRENT_OPTIONS,
             #                 lambda value: {"moduleType": 5, "operateType": "dcChgCfg",
             #                                "params": {"dcChgCfg": value}}),
-
-            #TimeoutDictSelectEntity(client, self, "pd.lcdOffSec", const.SCREEN_TIMEOUT, const.SCREEN_TIMEOUT_OPTIONS,
+            # TimeoutDictSelectEntity(client, self, "pd.lcdOffSec", const.SCREEN_TIMEOUT, const.SCREEN_TIMEOUT_OPTIONS,
             #                        lambda value: {"moduleType": 1, "operateType": "lcdCfg",
             #                                       "params": {"brighLevel": 255, "delayOff": value}}),
-
-            #TimeoutDictSelectEntity(client, self, "inv.cfgStandbyMin", const.UNIT_TIMEOUT, const.UNIT_TIMEOUT_OPTIONS,
+            # TimeoutDictSelectEntity(client, self, "inv.cfgStandbyMin", const.UNIT_TIMEOUT, const.UNIT_TIMEOUT_OPTIONS,
             #                        lambda value: {"moduleType": 1, "operateType": "standbyTime",
             #                                       "params": {"standbyMin": value}}),
-
-            #TimeoutDictSelectEntity(client, self, "mppt.acStandbyMins", const.AC_TIMEOUT, const.AC_TIMEOUT_OPTIONS,
+            # TimeoutDictSelectEntity(client, self, "mppt.acStandbyMins", const.AC_TIMEOUT, const.AC_TIMEOUT_OPTIONS,
             #                        lambda value: {"moduleType": 5, "operateType": "standbyTime",
             #                                       "params": {"standbyMins": value}}),
-
-            #TimeoutDictSelectEntity(client, self, "mppt.carStandbyMin", const.DC_TIMEOUT, const.DC_TIMEOUT_OPTIONS,
+            # TimeoutDictSelectEntity(client, self, "mppt.carStandbyMin", const.DC_TIMEOUT, const.DC_TIMEOUT_OPTIONS,
             #                        lambda value: {"moduleType": 5, "operateType": "carStandby",
             #                                       "params": {"standbyMins": value}})
-
         ]
 
     def _status_sensor(self, client: EcoflowApiClient) -> StatusSensorEntity:

--- a/custom_components/ecoflow_cloud/devices/internal/delta_mini.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_mini.py
@@ -1,14 +1,42 @@
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import const, BaseDevice
-from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, BaseSelectEntity
-from custom_components.ecoflow_cloud.number import ChargingPowerEntity, MaxBatteryLevelEntity, MinBatteryLevelEntity
-from custom_components.ecoflow_cloud.select import DictSelectEntity, TimeoutDictSelectEntity
-from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, TempSensorEntity, \
-    CyclesSensorEntity, \
-    InWattsSensorEntity, OutWattsSensorEntity, MilliVoltSensorEntity, \
-    InMilliVoltSensorEntity, OutMilliVoltSensorEntity, CapacitySensorEntity, InWattsSolarSensorEntity, \
-    InEnergySensorEntity, OutEnergySensorEntity, OutWattsDcSensorEntity, QuotaStatusSensorEntity, \
-    MilliampSensorEntity, InVoltSolarSensorEntity, InMilliampSolarSensorEntity, OutVoltDcSensorEntity
+from custom_components.ecoflow_cloud.entities import (
+    BaseSensorEntity,
+    BaseNumberEntity,
+    BaseSwitchEntity,
+    BaseSelectEntity,
+)
+from custom_components.ecoflow_cloud.number import (
+    ChargingPowerEntity,
+    MaxBatteryLevelEntity,
+    MinBatteryLevelEntity,
+)
+from custom_components.ecoflow_cloud.select import (
+    DictSelectEntity,
+    TimeoutDictSelectEntity,
+)
+from custom_components.ecoflow_cloud.sensor import (
+    LevelSensorEntity,
+    WattsSensorEntity,
+    RemainSensorEntity,
+    TempSensorEntity,
+    CyclesSensorEntity,
+    InWattsSensorEntity,
+    OutWattsSensorEntity,
+    MilliVoltSensorEntity,
+    InMilliVoltSensorEntity,
+    OutMilliVoltSensorEntity,
+    CapacitySensorEntity,
+    InWattsSolarSensorEntity,
+    InEnergySensorEntity,
+    OutEnergySensorEntity,
+    OutWattsDcSensorEntity,
+    QuotaStatusSensorEntity,
+    MilliampSensorEntity,
+    InVoltSolarSensorEntity,
+    InMilliampSolarSensorEntity,
+    OutVoltDcSensorEntity,
+)
 from custom_components.ecoflow_cloud.switch import BeeperEntity, EnabledEntity
 
 
@@ -16,80 +44,133 @@ class DeltaMini(BaseDevice):
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
             LevelSensorEntity(client, self, "bmsMaster.soc", const.MAIN_BATTERY_LEVEL)
-                .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            LevelSensorEntity(client, self, "bmsMaster.f32ShowSoc", const.MAIN_BATTERY_LEVEL_F32, False)
-                .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bmsMaster.designCap", const.MAIN_DESIGN_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bmsMaster.fullCap", const.MAIN_FULL_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bmsMaster.remainCap", const.MAIN_REMAIN_CAPACITY, False),
-
+            .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            LevelSensorEntity(
+                client,
+                self,
+                "bmsMaster.f32ShowSoc",
+                const.MAIN_BATTERY_LEVEL_F32,
+                False,
+            )
+            .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            CapacitySensorEntity(
+                client, self, "bmsMaster.designCap", const.MAIN_DESIGN_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bmsMaster.fullCap", const.MAIN_FULL_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bmsMaster.remainCap", const.MAIN_REMAIN_CAPACITY, False
+            ),
             LevelSensorEntity(client, self, "bmsMaster.soh", const.SOH),
-
-            LevelSensorEntity(client, self, "ems.lcdShowSoc", const.COMBINED_BATTERY_LEVEL),
-            LevelSensorEntity(client, self, "ems.f32LcdShowSoc", const.COMBINED_BATTERY_LEVEL_F32, False),
+            LevelSensorEntity(
+                client, self, "ems.lcdShowSoc", const.COMBINED_BATTERY_LEVEL
+            ),
+            LevelSensorEntity(
+                client,
+                self,
+                "ems.f32LcdShowSoc",
+                const.COMBINED_BATTERY_LEVEL_F32,
+                False,
+            ),
             WattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             WattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
-
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
-
             InMilliVoltSensorEntity(client, self, "inv.acInVol", const.AC_IN_VOLT),
             OutMilliVoltSensorEntity(client, self, "inv.invOutVol", const.AC_OUT_VOLT),
-
-            InWattsSolarSensorEntity(client, self, "mppt.inWatts", const.SOLAR_IN_POWER),
+            InWattsSolarSensorEntity(
+                client, self, "mppt.inWatts", const.SOLAR_IN_POWER
+            ),
             InVoltSolarSensorEntity(client, self, "mppt.inVol", const.SOLAR_IN_VOLTAGE),
-            InMilliampSolarSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT),
-
+            InMilliampSolarSensorEntity(
+                client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT
+            ),
             OutWattsDcSensorEntity(client, self, "mppt.outWatts", const.DC_OUT_POWER),
             OutVoltDcSensorEntity(client, self, "mppt.outVol", const.DC_OUT_VOLTAGE),
-
-            OutWattsDcSensorEntity(client, self, "mppt.carOutWatts", const.DC_CAR_OUT_POWER),
-            OutWattsDcSensorEntity(client, self, "mppt.dcdc12vWatts", const.DC_ANDERSON_OUT_POWER),
-
-            OutWattsSensorEntity(client, self, "pd.typec1Watts", const.TYPEC_1_OUT_POWER),
-            OutWattsSensorEntity(client, self, "pd.typec2Watts", const.TYPEC_2_OUT_POWER),
-
+            OutWattsDcSensorEntity(
+                client, self, "mppt.carOutWatts", const.DC_CAR_OUT_POWER
+            ),
+            OutWattsDcSensorEntity(
+                client, self, "mppt.dcdc12vWatts", const.DC_ANDERSON_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "pd.typec1Watts", const.TYPEC_1_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "pd.typec2Watts", const.TYPEC_2_OUT_POWER
+            ),
             OutWattsSensorEntity(client, self, "pd.usb1Watts", const.USB_1_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb2Watts", const.USB_2_OUT_POWER),
-
-            OutWattsSensorEntity(client, self, "pd.qcUsb1Watts", const.USB_QC_1_OUT_POWER),
-            OutWattsSensorEntity(client, self, "pd.qcUsb2Watts", const.USB_QC_2_OUT_POWER),
-
-            RemainSensorEntity(client, self, "ems.chgRemainTime", const.CHARGE_REMAINING_TIME),
-            RemainSensorEntity(client, self, "ems.dsgRemainTime", const.DISCHARGE_REMAINING_TIME),
+            OutWattsSensorEntity(
+                client, self, "pd.qcUsb1Watts", const.USB_QC_1_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "pd.qcUsb2Watts", const.USB_QC_2_OUT_POWER
+            ),
+            RemainSensorEntity(
+                client, self, "ems.chgRemainTime", const.CHARGE_REMAINING_TIME
+            ),
+            RemainSensorEntity(
+                client, self, "ems.dsgRemainTime", const.DISCHARGE_REMAINING_TIME
+            ),
             CyclesSensorEntity(client, self, "bmsMaster.cycles", const.CYCLES),
-
             TempSensorEntity(client, self, "bmsMaster.temp", const.BATTERY_TEMP, False)
-                .attr("bmsMaster.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-                .attr("bmsMaster.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-
-            MilliampSensorEntity(client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT, False),
-            MilliVoltSensorEntity(client, self, "bmsMaster.vol", const.BATTERY_VOLT, False)
-                .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
-                .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-
+            .attr("bmsMaster.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+            .attr("bmsMaster.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+            MilliampSensorEntity(
+                client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bmsMaster.vol", const.BATTERY_VOLT, False
+            )
+            .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
+            .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
             # https://github.com/tolwi/hassio-ecoflow-cloud/discussions/87
             InEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
             InEnergySensorEntity(client, self, "pd.chgPowerAc", const.CHARGE_AC_ENERGY),
             InEnergySensorEntity(client, self, "pd.chgPowerDc", const.CHARGE_DC_ENERGY),
-            OutEnergySensorEntity(client, self, "pd.dsgPowerAc", const.DISCHARGE_AC_ENERGY),
-            OutEnergySensorEntity(client, self, "pd.dsgPowerDc", const.DISCHARGE_DC_ENERGY),
-
-            QuotaStatusSensorEntity(client, self)
+            OutEnergySensorEntity(
+                client, self, "pd.dsgPowerAc", const.DISCHARGE_AC_ENERGY
+            ),
+            OutEnergySensorEntity(
+                client, self, "pd.dsgPowerDc", const.DISCHARGE_DC_ENERGY
+            ),
+            QuotaStatusSensorEntity(client, self),
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return [
-            MaxBatteryLevelEntity(client, self, "ems.maxChargeSoc", const.MAX_CHARGE_LEVEL, 50, 100,
-                                  lambda value: {"moduleType": 0, "operateType": "TCP",
-                                                 "params": {"id": 49, "maxChgSoc": value}}),
-            MinBatteryLevelEntity(client, self, "ems.minDsgSoc", const.MIN_DISCHARGE_LEVEL, 0, 30,
-                                  lambda value: {"moduleType": 0, "operateType": "TCP",
-                                                 "params": {"id": 51, "minDsgSoc": value}}),
+            MaxBatteryLevelEntity(
+                client,
+                self,
+                "ems.maxChargeSoc",
+                const.MAX_CHARGE_LEVEL,
+                50,
+                100,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 49, "maxChgSoc": value},
+                },
+            ),
+            MinBatteryLevelEntity(
+                client,
+                self,
+                "ems.minDsgSoc",
+                const.MIN_DISCHARGE_LEVEL,
+                0,
+                30,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 51, "minDsgSoc": value},
+                },
+            ),
             # MaxBatteryLevelEntity(client, self, "pd.bpPowerSoc", const.BACKUP_RESERVE_LEVEL, 5, 100,
             #                       lambda value: {"moduleType": 0, "operateType": "TCP",
             #                                      "params": {"isConfig": 1, "bpPowerSoc": int(value), "minDsgSoc": 0, "maxChgSoc": 0, "id": 94}}),
@@ -100,27 +181,67 @@ class DeltaMini(BaseDevice):
             # MaxGenStopLevelEntity(client, self, "ems.maxCloseOilEbSoc", const.GEN_AUTO_STOP_LEVEL, 50, 100,
             #                       lambda value: {"moduleType": 0, "operateType": "TCP",
             #                                      "params": {"closeOilSoc": value, "id": 53}}),
-
-            ChargingPowerEntity(client, self, "inv.cfgSlowChgWatts", const.AC_CHARGING_POWER, 200, 900,
-                                lambda value: {"moduleType": 0, "operateType": "TCP",
-                                               "params": {"slowChgPower": value, "id": 69}}),
-
+            ChargingPowerEntity(
+                client,
+                self,
+                "inv.cfgSlowChgWatts",
+                const.AC_CHARGING_POWER,
+                200,
+                900,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"slowChgPower": value, "id": 69},
+                },
+            ),
         ]
 
     def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
         return [
-            BeeperEntity(client, self, "mppt.beepState", const.BEEPER,
-                         lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 38, "enabled": value}}),
-            EnabledEntity(client, self, "mppt.carState", const.DC_ENABLED,
-                          lambda value: {"moduleType": 0, "operateType": "TCP",
-                                         "params": {"id": 81, "enabled": value}}),
-            EnabledEntity(client, self, "inv.cfgAcEnabled", const.AC_ENABLED,
-                          lambda value: {"moduleType": 0, "operateType": "TCP",
-                                         "params": {"id": 66, "enabled": value}}),
-
-            EnabledEntity(client, self, "inv.cfgAcXboost", const.XBOOST_ENABLED,
-                          lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 66, "xboost": value}}),
-
+            BeeperEntity(
+                client,
+                self,
+                "mppt.beepState",
+                const.BEEPER,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 38, "enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "mppt.carState",
+                const.DC_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 81, "enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "inv.cfgAcEnabled",
+                const.AC_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 66, "enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "inv.cfgAcXboost",
+                const.XBOOST_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 66, "xboost": value},
+                },
+            ),
             # EnabledEntity(client, self, "inv.acPassByAutoEn", const.AC_ALWAYS_ENABLED,
             #               lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 84, "enabled": value}}),
             # EnabledEntity(client, self, "pd.bpPowerSoc", const.BP_ENABLED,
@@ -129,20 +250,52 @@ class DeltaMini(BaseDevice):
 
     def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:
         return [
-            DictSelectEntity(client, self, "mppt.cfgDcChgCurrent", const.DC_CHARGE_CURRENT, const.DC_CHARGE_CURRENT_OPTIONS,
-                             lambda value: {"moduleType": 0, "operateType": "TCP",
-                                            "params": {"currMa": value, "id": 71}}),
-
-            TimeoutDictSelectEntity(client, self, "pd.lcdOffSec", const.SCREEN_TIMEOUT, const.SCREEN_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 0, "operateType": "TCP",
-                                                   "params": {"lcdTime": value, "id": 39}}),
-
-            TimeoutDictSelectEntity(client, self, "pd.standByMode", const.UNIT_TIMEOUT, const.UNIT_TIMEOUT_OPTIONS_LIMITED,
-                                    lambda value: {"moduleType": 0, "operateType": "TCP",
-                                                   "params": {"standByMode": value, "id": 33}}),
-
-            TimeoutDictSelectEntity(client, self, "inv.cfgStandbyMin", const.AC_TIMEOUT, const.AC_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 0, "operateType": "TCP",
-                                                   "params": {"standByMins": value, "id": 153}}),
-
+            DictSelectEntity(
+                client,
+                self,
+                "mppt.cfgDcChgCurrent",
+                const.DC_CHARGE_CURRENT,
+                const.DC_CHARGE_CURRENT_OPTIONS,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"currMa": value, "id": 71},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "pd.lcdOffSec",
+                const.SCREEN_TIMEOUT,
+                const.SCREEN_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"lcdTime": value, "id": 39},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "pd.standByMode",
+                const.UNIT_TIMEOUT,
+                const.UNIT_TIMEOUT_OPTIONS_LIMITED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"standByMode": value, "id": 33},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "inv.cfgStandbyMin",
+                const.AC_TIMEOUT,
+                const.AC_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"standByMins": value, "id": 153},
+                },
+            ),
         ]

--- a/custom_components/ecoflow_cloud/devices/internal/delta_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_pro.py
@@ -1,17 +1,44 @@
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import const, BaseDevice
-from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, \
-    BaseSelectEntity
-from custom_components.ecoflow_cloud.number import ChargingPowerEntity, MaxBatteryLevelEntity, MinBatteryLevelEntity, \
-    MinGenStartLevelEntity, \
-    MaxGenStopLevelEntity
-from custom_components.ecoflow_cloud.select import DictSelectEntity, TimeoutDictSelectEntity
-from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, TempSensorEntity, \
-    CyclesSensorEntity, \
-    InWattsSensorEntity, OutWattsSensorEntity, MilliVoltSensorEntity, \
-    InMilliVoltSensorEntity, OutMilliVoltSensorEntity, CapacitySensorEntity, InWattsSolarSensorEntity, \
-    InEnergySensorEntity, OutEnergySensorEntity, OutWattsDcSensorEntity, QuotaStatusSensorEntity, \
-    MilliampSensorEntity, InVoltSolarSensorEntity, InMilliampSolarSensorEntity, OutVoltDcSensorEntity
+from custom_components.ecoflow_cloud.entities import (
+    BaseSensorEntity,
+    BaseNumberEntity,
+    BaseSwitchEntity,
+    BaseSelectEntity,
+)
+from custom_components.ecoflow_cloud.number import (
+    ChargingPowerEntity,
+    MaxBatteryLevelEntity,
+    MinBatteryLevelEntity,
+    MinGenStartLevelEntity,
+    MaxGenStopLevelEntity,
+)
+from custom_components.ecoflow_cloud.select import (
+    DictSelectEntity,
+    TimeoutDictSelectEntity,
+)
+from custom_components.ecoflow_cloud.sensor import (
+    LevelSensorEntity,
+    WattsSensorEntity,
+    RemainSensorEntity,
+    TempSensorEntity,
+    CyclesSensorEntity,
+    InWattsSensorEntity,
+    OutWattsSensorEntity,
+    MilliVoltSensorEntity,
+    InMilliVoltSensorEntity,
+    OutMilliVoltSensorEntity,
+    CapacitySensorEntity,
+    InWattsSolarSensorEntity,
+    InEnergySensorEntity,
+    OutEnergySensorEntity,
+    OutWattsDcSensorEntity,
+    QuotaStatusSensorEntity,
+    MilliampSensorEntity,
+    InVoltSolarSensorEntity,
+    InMilliampSolarSensorEntity,
+    OutVoltDcSensorEntity,
+)
 from custom_components.ecoflow_cloud.switch import BeeperEntity, EnabledEntity
 
 
@@ -19,189 +46,516 @@ class DeltaPro(BaseDevice):
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
             LevelSensorEntity(client, self, "bmsMaster.soc", const.MAIN_BATTERY_LEVEL)
-                .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            LevelSensorEntity(client, self, "bmsMaster.f32ShowSoc", const.MAIN_BATTERY_LEVEL_F32, False)
-                .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bmsMaster.designCap", const.MAIN_DESIGN_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bmsMaster.fullCap", const.MAIN_FULL_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bmsMaster.remainCap", const.MAIN_REMAIN_CAPACITY, False),
-
+            .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            LevelSensorEntity(
+                client,
+                self,
+                "bmsMaster.f32ShowSoc",
+                const.MAIN_BATTERY_LEVEL_F32,
+                False,
+            )
+            .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            CapacitySensorEntity(
+                client, self, "bmsMaster.designCap", const.MAIN_DESIGN_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bmsMaster.fullCap", const.MAIN_FULL_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bmsMaster.remainCap", const.MAIN_REMAIN_CAPACITY, False
+            ),
             LevelSensorEntity(client, self, "bmsMaster.soh", const.SOH),
-
-            LevelSensorEntity(client, self, "ems.lcdShowSoc", const.COMBINED_BATTERY_LEVEL),
-            LevelSensorEntity(client, self, "ems.f32LcdShowSoc", const.COMBINED_BATTERY_LEVEL_F32, False),
+            LevelSensorEntity(
+                client, self, "ems.lcdShowSoc", const.COMBINED_BATTERY_LEVEL
+            ),
+            LevelSensorEntity(
+                client,
+                self,
+                "ems.f32LcdShowSoc",
+                const.COMBINED_BATTERY_LEVEL_F32,
+                False,
+            ),
             WattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             WattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
-
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
-
             InMilliVoltSensorEntity(client, self, "inv.acInVol", const.AC_IN_VOLT),
             OutMilliVoltSensorEntity(client, self, "inv.invOutVol", const.AC_OUT_VOLT),
-
-            InWattsSolarSensorEntity(client, self, "mppt.inWatts", const.SOLAR_IN_POWER),
+            InWattsSolarSensorEntity(
+                client, self, "mppt.inWatts", const.SOLAR_IN_POWER
+            ),
             InVoltSolarSensorEntity(client, self, "mppt.inVol", const.SOLAR_IN_VOLTAGE),
-            InMilliampSolarSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT),
-
+            InMilliampSolarSensorEntity(
+                client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT
+            ),
             OutWattsDcSensorEntity(client, self, "mppt.outWatts", const.DC_OUT_POWER),
             OutVoltDcSensorEntity(client, self, "mppt.outVol", const.DC_OUT_VOLTAGE),
-
-            OutWattsDcSensorEntity(client, self, "mppt.carOutWatts", const.DC_CAR_OUT_POWER),
-            OutWattsDcSensorEntity(client, self, "mppt.dcdc12vWatts", const.DC_ANDERSON_OUT_POWER),
-
-            OutWattsSensorEntity(client, self, "pd.typec1Watts", const.TYPEC_1_OUT_POWER),
-            OutWattsSensorEntity(client, self, "pd.typec2Watts", const.TYPEC_2_OUT_POWER),
-
+            OutWattsDcSensorEntity(
+                client, self, "mppt.carOutWatts", const.DC_CAR_OUT_POWER
+            ),
+            OutWattsDcSensorEntity(
+                client, self, "mppt.dcdc12vWatts", const.DC_ANDERSON_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "pd.typec1Watts", const.TYPEC_1_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "pd.typec2Watts", const.TYPEC_2_OUT_POWER
+            ),
             OutWattsSensorEntity(client, self, "pd.usb1Watts", const.USB_1_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb2Watts", const.USB_2_OUT_POWER),
-
-            OutWattsSensorEntity(client, self, "pd.qcUsb1Watts", const.USB_QC_1_OUT_POWER),
-            OutWattsSensorEntity(client, self, "pd.qcUsb2Watts", const.USB_QC_2_OUT_POWER),
-
-            RemainSensorEntity(client, self, "ems.chgRemainTime", const.CHARGE_REMAINING_TIME),
-            RemainSensorEntity(client, self, "ems.dsgRemainTime", const.DISCHARGE_REMAINING_TIME),
+            OutWattsSensorEntity(
+                client, self, "pd.qcUsb1Watts", const.USB_QC_1_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "pd.qcUsb2Watts", const.USB_QC_2_OUT_POWER
+            ),
+            RemainSensorEntity(
+                client, self, "ems.chgRemainTime", const.CHARGE_REMAINING_TIME
+            ),
+            RemainSensorEntity(
+                client, self, "ems.dsgRemainTime", const.DISCHARGE_REMAINING_TIME
+            ),
             CyclesSensorEntity(client, self, "bmsMaster.cycles", const.CYCLES),
-
             TempSensorEntity(client, self, "bmsMaster.temp", const.BATTERY_TEMP)
-                .attr("bmsMaster.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-                .attr("bmsMaster.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            TempSensorEntity(client, self, "bmsMaster.minCellTemp", const.MIN_CELL_TEMP, False),
-            TempSensorEntity(client, self, "bmsMaster.maxCellTemp", const.MAX_CELL_TEMP, False),
-
-            MilliampSensorEntity(client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT, False),
-            MilliVoltSensorEntity(client, self, "bmsMaster.vol", const.BATTERY_VOLT, False)
-                .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
-                .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            MilliVoltSensorEntity(client, self, "bmsMaster.minCellVol", const.MIN_CELL_VOLT, False),
-            MilliVoltSensorEntity(client, self, "bmsMaster.maxCellVol", const.MAX_CELL_VOLT, False),
-
+            .attr("bmsMaster.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+            .attr("bmsMaster.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+            TempSensorEntity(
+                client, self, "bmsMaster.minCellTemp", const.MIN_CELL_TEMP, False
+            ),
+            TempSensorEntity(
+                client, self, "bmsMaster.maxCellTemp", const.MAX_CELL_TEMP, False
+            ),
+            MilliampSensorEntity(
+                client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bmsMaster.vol", const.BATTERY_VOLT, False
+            )
+            .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
+            .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
+            MilliVoltSensorEntity(
+                client, self, "bmsMaster.minCellVol", const.MIN_CELL_VOLT, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bmsMaster.maxCellVol", const.MAX_CELL_VOLT, False
+            ),
             # https://github.com/tolwi/hassio-ecoflow-cloud/discussions/87
             InEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
             InEnergySensorEntity(client, self, "pd.chgPowerAc", const.CHARGE_AC_ENERGY),
             InEnergySensorEntity(client, self, "pd.chgPowerDc", const.CHARGE_DC_ENERGY),
-            OutEnergySensorEntity(client, self, "pd.dsgPowerAc", const.DISCHARGE_AC_ENERGY),
-            OutEnergySensorEntity(client, self, "pd.dsgPowerDc", const.DISCHARGE_DC_ENERGY),
-
+            OutEnergySensorEntity(
+                client, self, "pd.dsgPowerAc", const.DISCHARGE_AC_ENERGY
+            ),
+            OutEnergySensorEntity(
+                client, self, "pd.dsgPowerDc", const.DISCHARGE_DC_ENERGY
+            ),
             # Optional Slave Batteries
-            LevelSensorEntity(client, self, "bmsSlave1.soc", const.SLAVE_N_BATTERY_LEVEL % 1, False, True)
-                .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            LevelSensorEntity(client, self, "bmsSlave1.f32ShowSoc", const.SLAVE_N_BATTERY_LEVEL_F32 % 1, False, False)
-                .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bmsSlave1.designCap", const.SLAVE_N_DESIGN_CAPACITY % 1, False),
-            CapacitySensorEntity(client, self, "bmsSlave1.fullCap", const.SLAVE_N_FULL_CAPACITY % 1, False),
-            CapacitySensorEntity(client, self, "bmsSlave1.remainCap", const.SLAVE_N_REMAIN_CAPACITY % 1, False),
+            LevelSensorEntity(
+                client,
+                self,
+                "bmsSlave1.soc",
+                const.SLAVE_N_BATTERY_LEVEL % 1,
+                False,
+                True,
+            )
+            .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            LevelSensorEntity(
+                client,
+                self,
+                "bmsSlave1.f32ShowSoc",
+                const.SLAVE_N_BATTERY_LEVEL_F32 % 1,
+                False,
+                False,
+            )
+            .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bmsSlave1.designCap",
+                const.SLAVE_N_DESIGN_CAPACITY % 1,
+                False,
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bmsSlave1.fullCap",
+                const.SLAVE_N_FULL_CAPACITY % 1,
+                False,
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bmsSlave1.remainCap",
+                const.SLAVE_N_REMAIN_CAPACITY % 1,
+                False,
+            ),
             LevelSensorEntity(client, self, "bmsSlave1.soh", const.SLAVE_N_SOH % 1),
-
-            TempSensorEntity(client, self, "bmsSlave1.temp", const.SLAVE_N_BATTERY_TEMP % 1, False, True)
+            TempSensorEntity(
+                client,
+                self,
+                "bmsSlave1.temp",
+                const.SLAVE_N_BATTERY_TEMP % 1,
+                False,
+                True,
+            )
             .attr("bmsSlave1.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
             .attr("bmsSlave1.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            WattsSensorEntity(client, self, "bmsSlave1.inputWatts", const.SLAVE_N_IN_POWER % 1, False, True),
-            WattsSensorEntity(client, self, "bmsSlave1.outputWatts", const.SLAVE_N_OUT_POWER % 1, False, True),
-
-            LevelSensorEntity(client, self, "bmsSlave2.soc", const.SLAVE_N_BATTERY_LEVEL % 2, False, True)
-                .attr("bmsSlave2.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsSlave2.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsSlave2.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            LevelSensorEntity(client, self, "bmsSlave2.f32ShowSoc", const.SLAVE_N_BATTERY_LEVEL_F32 % 2, False, False)
-                .attr("bmsSlave2.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsSlave2.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsSlave2.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bmsSlave2.designCap", const.SLAVE_N_DESIGN_CAPACITY % 2, False),
-            CapacitySensorEntity(client, self, "bmsSlave2.fullCap", const.SLAVE_N_FULL_CAPACITY % 2, False),
-            CapacitySensorEntity(client, self, "bmsSlave2.remainCap", const.SLAVE_N_REMAIN_CAPACITY % 2, False),
+            WattsSensorEntity(
+                client,
+                self,
+                "bmsSlave1.inputWatts",
+                const.SLAVE_N_IN_POWER % 1,
+                False,
+                True,
+            ),
+            WattsSensorEntity(
+                client,
+                self,
+                "bmsSlave1.outputWatts",
+                const.SLAVE_N_OUT_POWER % 1,
+                False,
+                True,
+            ),
+            LevelSensorEntity(
+                client,
+                self,
+                "bmsSlave2.soc",
+                const.SLAVE_N_BATTERY_LEVEL % 2,
+                False,
+                True,
+            )
+            .attr("bmsSlave2.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsSlave2.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsSlave2.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            LevelSensorEntity(
+                client,
+                self,
+                "bmsSlave2.f32ShowSoc",
+                const.SLAVE_N_BATTERY_LEVEL_F32 % 2,
+                False,
+                False,
+            )
+            .attr("bmsSlave2.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsSlave2.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsSlave2.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bmsSlave2.designCap",
+                const.SLAVE_N_DESIGN_CAPACITY % 2,
+                False,
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bmsSlave2.fullCap",
+                const.SLAVE_N_FULL_CAPACITY % 2,
+                False,
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bmsSlave2.remainCap",
+                const.SLAVE_N_REMAIN_CAPACITY % 2,
+                False,
+            ),
             LevelSensorEntity(client, self, "bmsSlave2.soh", const.SLAVE_N_SOH % 2),
-            MilliVoltSensorEntity(client, self, "bmsSlave1.vol", const.SLAVE_N_BATTERY_VOLT % 1, False),
-            MilliVoltSensorEntity(client, self, "bmsSlave1.minCellVol", const.SLAVE_N_MIN_CELL_VOLT % 1, False),
-            MilliVoltSensorEntity(client, self, "bmsSlave1.maxCellVol", const.SLAVE_N_MAX_CELL_VOLT % 1, False),
-            MilliampSensorEntity(client, self, "bmsSlave1.amp", const.SLAVE_N_BATTERY_CURRENT % 1, False),
-            MilliVoltSensorEntity(client, self, "bmsSlave2.vol", const.SLAVE_N_BATTERY_VOLT % 2, False),
-            MilliVoltSensorEntity(client, self, "bmsSlave2.minCellVol", const.SLAVE_N_MIN_CELL_VOLT % 2, False),
-            MilliVoltSensorEntity(client, self, "bmsSlave2.maxCellVol", const.SLAVE_N_MAX_CELL_VOLT % 2, False),
-            MilliampSensorEntity(client, self, "bmsSlave2.amp", const.SLAVE_N_BATTERY_CURRENT % 2, False),
-            TempSensorEntity(client, self, "bmsSlave2.temp", const.SLAVE_N_BATTERY_TEMP % 2, False, True)
-                .attr("bmsSlave2.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-                .attr("bmsSlave2.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            WattsSensorEntity(client, self, "bmsSlave2.inputWatts", const.SLAVE_N_IN_POWER % 2, False, True),
-            WattsSensorEntity(client, self, "bmsSlave2.outputWatts", const.SLAVE_N_OUT_POWER % 2, False, True),
-            CyclesSensorEntity(client, self, "bmsSlave1.cycles", const.SLAVE_N_CYCLES % 1, False),
-            CyclesSensorEntity(client, self, "bmsSlave2.cycles", const.SLAVE_N_CYCLES % 2, False),
-            QuotaStatusSensorEntity(client, self)
+            MilliVoltSensorEntity(
+                client, self, "bmsSlave1.vol", const.SLAVE_N_BATTERY_VOLT % 1, False
+            ),
+            MilliVoltSensorEntity(
+                client,
+                self,
+                "bmsSlave1.minCellVol",
+                const.SLAVE_N_MIN_CELL_VOLT % 1,
+                False,
+            ),
+            MilliVoltSensorEntity(
+                client,
+                self,
+                "bmsSlave1.maxCellVol",
+                const.SLAVE_N_MAX_CELL_VOLT % 1,
+                False,
+            ),
+            MilliampSensorEntity(
+                client, self, "bmsSlave1.amp", const.SLAVE_N_BATTERY_CURRENT % 1, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bmsSlave2.vol", const.SLAVE_N_BATTERY_VOLT % 2, False
+            ),
+            MilliVoltSensorEntity(
+                client,
+                self,
+                "bmsSlave2.minCellVol",
+                const.SLAVE_N_MIN_CELL_VOLT % 2,
+                False,
+            ),
+            MilliVoltSensorEntity(
+                client,
+                self,
+                "bmsSlave2.maxCellVol",
+                const.SLAVE_N_MAX_CELL_VOLT % 2,
+                False,
+            ),
+            MilliampSensorEntity(
+                client, self, "bmsSlave2.amp", const.SLAVE_N_BATTERY_CURRENT % 2, False
+            ),
+            TempSensorEntity(
+                client,
+                self,
+                "bmsSlave2.temp",
+                const.SLAVE_N_BATTERY_TEMP % 2,
+                False,
+                True,
+            )
+            .attr("bmsSlave2.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+            .attr("bmsSlave2.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+            WattsSensorEntity(
+                client,
+                self,
+                "bmsSlave2.inputWatts",
+                const.SLAVE_N_IN_POWER % 2,
+                False,
+                True,
+            ),
+            WattsSensorEntity(
+                client,
+                self,
+                "bmsSlave2.outputWatts",
+                const.SLAVE_N_OUT_POWER % 2,
+                False,
+                True,
+            ),
+            CyclesSensorEntity(
+                client, self, "bmsSlave1.cycles", const.SLAVE_N_CYCLES % 1, False
+            ),
+            CyclesSensorEntity(
+                client, self, "bmsSlave2.cycles", const.SLAVE_N_CYCLES % 2, False
+            ),
+            QuotaStatusSensorEntity(client, self),
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return [
-            MaxBatteryLevelEntity(client, self, "ems.maxChargeSoc", const.MAX_CHARGE_LEVEL, 50, 100,
-                                  lambda value: {"moduleType": 0, "operateType": "TCP",
-                                                 "params": {"id": 49, "maxChgSoc": value}}),
-            MinBatteryLevelEntity(client, self, "ems.minDsgSoc", const.MIN_DISCHARGE_LEVEL, 0, 30,
-                                  lambda value: {"moduleType": 0, "operateType": "TCP",
-                                                 "params": {"id": 51, "minDsgSoc": value}}),
-            MaxBatteryLevelEntity(client, self, "pd.bppowerSoc", const.BACKUP_RESERVE_LEVEL, 5, 100,
-                                  lambda value: {"moduleType": 0, "operateType": "TCP",
-                                                 "params": {"isConfig": 1, "bpPowerSoc": int(value), "minDsgSoc": 0,
-                                                            "maxChgSoc": 0, "id": 94}}),
-            MinGenStartLevelEntity(client, self, "ems.minOpenOilEbSoc", const.GEN_AUTO_START_LEVEL, 0, 30,
-                                   lambda value: {"moduleType": 0, "operateType": "TCP",
-                                                  "params": {"openOilSoc": value, "id": 52}}),
-
-            MaxGenStopLevelEntity(client, self, "ems.maxCloseOilEbSoc", const.GEN_AUTO_STOP_LEVEL, 50, 100,
-                                  lambda value: {"moduleType": 0, "operateType": "TCP",
-                                                 "params": {"closeOilSoc": value, "id": 53}}),
-
-            ChargingPowerEntity(client, self, "inv.cfgSlowChgWatts", const.AC_CHARGING_POWER, 200, 2900,
-                                lambda value: {"moduleType": 0, "operateType": "TCP",
-                                               "params": {"slowChgPower": value, "id": 69}}),
-
+            MaxBatteryLevelEntity(
+                client,
+                self,
+                "ems.maxChargeSoc",
+                const.MAX_CHARGE_LEVEL,
+                50,
+                100,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 49, "maxChgSoc": value},
+                },
+            ),
+            MinBatteryLevelEntity(
+                client,
+                self,
+                "ems.minDsgSoc",
+                const.MIN_DISCHARGE_LEVEL,
+                0,
+                30,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 51, "minDsgSoc": value},
+                },
+            ),
+            MaxBatteryLevelEntity(
+                client,
+                self,
+                "pd.bppowerSoc",
+                const.BACKUP_RESERVE_LEVEL,
+                5,
+                100,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {
+                        "isConfig": 1,
+                        "bpPowerSoc": int(value),
+                        "minDsgSoc": 0,
+                        "maxChgSoc": 0,
+                        "id": 94,
+                    },
+                },
+            ),
+            MinGenStartLevelEntity(
+                client,
+                self,
+                "ems.minOpenOilEbSoc",
+                const.GEN_AUTO_START_LEVEL,
+                0,
+                30,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"openOilSoc": value, "id": 52},
+                },
+            ),
+            MaxGenStopLevelEntity(
+                client,
+                self,
+                "ems.maxCloseOilEbSoc",
+                const.GEN_AUTO_STOP_LEVEL,
+                50,
+                100,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"closeOilSoc": value, "id": 53},
+                },
+            ),
+            ChargingPowerEntity(
+                client,
+                self,
+                "inv.cfgSlowChgWatts",
+                const.AC_CHARGING_POWER,
+                200,
+                2900,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"slowChgPower": value, "id": 69},
+                },
+            ),
         ]
 
     def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
         return [
-            BeeperEntity(client, self, "pd.beepState", const.BEEPER,
-                         lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 38, "enabled": value}}),
-            EnabledEntity(client, self, "mppt.carState", const.DC_ENABLED,
-                          lambda value: {"moduleType": 0, "operateType": "TCP",
-                                         "params": {"id": 81, "enabled": value}}),
-            EnabledEntity(client, self, "inv.cfgAcEnabled", const.AC_ENABLED,
-                          lambda value: {"moduleType": 0, "operateType": "TCP",
-                                         "params": {"id": 66, "enabled": value}}),
-
-            EnabledEntity(client, self, "inv.cfgAcXboost", const.XBOOST_ENABLED,
-                          lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 66, "xboost": value}}),
-            EnabledEntity(client, self, "pd.acautooutConfig", const.AC_ALWAYS_ENABLED,
-                          lambda value: {"moduleType": 0, "operateType": "TCP",
-                                         "params": {"id": 95, "acautooutConfig": value}}),
-            EnabledEntity(client, self, "pd.watthisconfig", const.BP_ENABLED,
-                          lambda value, params: {"moduleType": 0, "operateType": "TCP",
-                                                 "params": {"id": 94, "isConfig": value,
-                                                            "bpPowerSoc": value * 50,
-                                                            "minDsgSoc": 0,
-                                                            "maxChgSoc": 0}}),
+            BeeperEntity(
+                client,
+                self,
+                "pd.beepState",
+                const.BEEPER,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 38, "enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "mppt.carState",
+                const.DC_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 81, "enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "inv.cfgAcEnabled",
+                const.AC_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 66, "enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "inv.cfgAcXboost",
+                const.XBOOST_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 66, "xboost": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.acautooutConfig",
+                const.AC_ALWAYS_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 95, "acautooutConfig": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.watthisconfig",
+                const.BP_ENABLED,
+                lambda value, params: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {
+                        "id": 94,
+                        "isConfig": value,
+                        "bpPowerSoc": value * 50,
+                        "minDsgSoc": 0,
+                        "maxChgSoc": 0,
+                    },
+                },
+            ),
         ]
 
     def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:
         return [
-            DictSelectEntity(client, self, "mppt.cfgDcChgCurrent", const.DC_CHARGE_CURRENT, const.DC_CHARGE_CURRENT_OPTIONS,
-                             lambda value: {"moduleType": 0, "operateType": "TCP",
-                                            "params": {"currMa": value, "id": 71}}),
-
-            TimeoutDictSelectEntity(client, self, "pd.lcdOffSec", const.SCREEN_TIMEOUT, const.SCREEN_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 0, "operateType": "TCP",
-                                                   "params": {"lcdTime": value, "id": 39}}),
-
-            TimeoutDictSelectEntity(client, self, "pd.standByMode", const.UNIT_TIMEOUT, const.UNIT_TIMEOUT_OPTIONS_LIMITED,
-                                    lambda value: {"moduleType": 0, "operateType": "TCP",
-                                                   "params": {"standByMode": value, "id": 33}}),
-
-            TimeoutDictSelectEntity(client, self, "inv.cfgStandbyMin", const.AC_TIMEOUT, const.AC_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 0, "operateType": "TCP",
-                                                   "params": {"standByMins": value, "id": 153}}),
-
+            DictSelectEntity(
+                client,
+                self,
+                "mppt.cfgDcChgCurrent",
+                const.DC_CHARGE_CURRENT,
+                const.DC_CHARGE_CURRENT_OPTIONS,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"currMa": value, "id": 71},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "pd.lcdOffSec",
+                const.SCREEN_TIMEOUT,
+                const.SCREEN_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"lcdTime": value, "id": 39},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "pd.standByMode",
+                const.UNIT_TIMEOUT,
+                const.UNIT_TIMEOUT_OPTIONS_LIMITED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"standByMode": value, "id": 33},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "inv.cfgStandbyMin",
+                const.AC_TIMEOUT,
+                const.AC_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"standByMins": value, "id": 153},
+                },
+            ),
         ]

--- a/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
@@ -32,7 +32,9 @@ from ..internal.proto import deltapro3_pb2
 
 
 class DeltaPro3SetMessage(Message, PrivateAPIMessageProtocol):
-    def __init__(self, device_sn: str, field: str, value: int, data_len: int | None = None) -> None:
+    def __init__(
+        self, device_sn: str, field: str, value: int, data_len: int | None = None
+    ) -> None:
         super().__init__()
         self.device_sn = device_sn
         self.field = field
@@ -83,10 +85,18 @@ class DeltaPro3(BaseDevice):
                 client, self, "bmsDesignCap", const.MAIN_DESIGN_CAPACITY, False
             ),
             LevelSensorEntity(client, self, "bmsBattSoh", const.SOH),
-            RemainSensorEntity(client, self, "bmsChgRemTime", const.CHARGE_REMAINING_TIME),
-            RemainSensorEntity(client, self, "bmsDsgRemTime", const.DISCHARGE_REMAINING_TIME),
-            TempSensorEntity(client, self, "bmsMinCellTemp", const.MIN_CELL_TEMP, False),
-            TempSensorEntity(client, self, "bmsMaxCellTemp", const.MAX_CELL_TEMP, False),
+            RemainSensorEntity(
+                client, self, "bmsChgRemTime", const.CHARGE_REMAINING_TIME
+            ),
+            RemainSensorEntity(
+                client, self, "bmsDsgRemTime", const.DISCHARGE_REMAINING_TIME
+            ),
+            TempSensorEntity(
+                client, self, "bmsMinCellTemp", const.MIN_CELL_TEMP, False
+            ),
+            TempSensorEntity(
+                client, self, "bmsMaxCellTemp", const.MAX_CELL_TEMP, False
+            ),
             TempSensorEntity(client, self, "bmsMinMosTemp", const.MIN_MOS_TEMP, False),
             TempSensorEntity(client, self, "bmsMaxMosTemp", const.MAX_MOS_TEMP, False),
             LevelSensorEntity(client, self, "cmsBattSoc", const.COMBINED_BATTERY_LEVEL),
@@ -103,19 +113,41 @@ class DeltaPro3(BaseDevice):
             OutWattsSensorEntity(client, self, "powGet12v", const.DC_12V_OUT_POWER),
             OutWattsSensorEntity(client, self, "powGet24v", const.DC_24V_OUT_POWER),
             OutWattsSensorEntity(client, self, "powGetAcLvOut", const.AC_LV_OUT_POWER),
-            OutWattsSensorEntity(client, self, "powGetAcLvTt30Out", const.AC_LV_TT30_OUT_POWER),
+            OutWattsSensorEntity(
+                client, self, "powGetAcLvTt30Out", const.AC_LV_TT30_OUT_POWER
+            ),
             OutWattsSensorEntity(client, self, "powGet5p8", const.POWER_INOUT_PORT),
-            OutWattsSensorEntity(client, self, "powGetQcusb1", const.USB_QC_1_OUT_POWER),
-            OutWattsSensorEntity(client, self, "powGetQcusb2", const.USB_QC_2_OUT_POWER),
-            OutWattsSensorEntity(client, self, "powGet4p81", const.EXTRA_BATTERY_1_OUT_POWER),
-            OutWattsSensorEntity(client, self, "powGet4p82", const.EXTRA_BATTERY_2_OUT_POWER),
+            OutWattsSensorEntity(
+                client, self, "powGetQcusb1", const.USB_QC_1_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "powGetQcusb2", const.USB_QC_2_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "powGet4p81", const.EXTRA_BATTERY_1_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "powGet4p82", const.EXTRA_BATTERY_2_OUT_POWER
+            ),
             FrequencySensorEntity(client, self, "acOutFreq", const.AC_FREQUENCY),
-            VoltSensorEntity(client, self, "plugInInfoPvHChgVolMax", const.PV_VOLTAGE, False),
-            AmpSensorEntity(client, self, "plugInInfoPvHChgAmpMax", const.PV_CURRENT, False),
-            VoltSensorEntity(client, self, "plugInInfoPvLChgVolMax", const.PV_VOLTAGE, False),
-            AmpSensorEntity(client, self, "plugInInfoPvLChgAmpMax", const.PV_CURRENT, False),
-            RemainSensorEntity(client, self, "cmsChgRemTime", const.CHARGE_REMAINING_TIME),
-            RemainSensorEntity(client, self, "cmsDsgRemTime", const.DISCHARGE_REMAINING_TIME),
+            VoltSensorEntity(
+                client, self, "plugInInfoPvHChgVolMax", const.PV_VOLTAGE, False
+            ),
+            AmpSensorEntity(
+                client, self, "plugInInfoPvHChgAmpMax", const.PV_CURRENT, False
+            ),
+            VoltSensorEntity(
+                client, self, "plugInInfoPvLChgVolMax", const.PV_VOLTAGE, False
+            ),
+            AmpSensorEntity(
+                client, self, "plugInInfoPvLChgAmpMax", const.PV_CURRENT, False
+            ),
+            RemainSensorEntity(
+                client, self, "cmsChgRemTime", const.CHARGE_REMAINING_TIME
+            ),
+            RemainSensorEntity(
+                client, self, "cmsDsgRemTime", const.DISCHARGE_REMAINING_TIME
+            ),
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:

--- a/custom_components/ecoflow_cloud/devices/internal/glacier.py
+++ b/custom_components/ecoflow_cloud/devices/internal/glacier.py
@@ -1,15 +1,32 @@
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.button import EnabledButtonEntity
 from custom_components.ecoflow_cloud.devices import const, BaseDevice
-from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, \
-    BaseSelectEntity, BaseButtonEntity
+from custom_components.ecoflow_cloud.entities import (
+    BaseSensorEntity,
+    BaseNumberEntity,
+    BaseSwitchEntity,
+    BaseSelectEntity,
+    BaseButtonEntity,
+)
 from custom_components.ecoflow_cloud.number import SetTempEntity
-from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, RemainSensorEntity, SecondsRemainSensorEntity, \
-    TempSensorEntity, \
-    CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity, VoltSensorEntity, MilliVoltSensorEntity, \
-    ChargingStateSensorEntity, \
-    FanSensorEntity, MiscBinarySensorEntity, DecicelsiusSensorEntity, MiscSensorEntity, CapacitySensorEntity, \
-    QuotaStatusSensorEntity
+from custom_components.ecoflow_cloud.sensor import (
+    LevelSensorEntity,
+    RemainSensorEntity,
+    SecondsRemainSensorEntity,
+    TempSensorEntity,
+    CyclesSensorEntity,
+    InWattsSensorEntity,
+    OutWattsSensorEntity,
+    VoltSensorEntity,
+    MilliVoltSensorEntity,
+    ChargingStateSensorEntity,
+    FanSensorEntity,
+    MiscBinarySensorEntity,
+    DecicelsiusSensorEntity,
+    MiscSensorEntity,
+    CapacitySensorEntity,
+    QuotaStatusSensorEntity,
+)
 from custom_components.ecoflow_cloud.switch import EnabledEntity, InvertedBeeperEntity
 
 
@@ -22,113 +39,220 @@ class Glacier(BaseDevice):
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
             # Power and Battery Entities
-            LevelSensorEntity(client, self, "bms_bmsStatus.soc", const.MAIN_BATTERY_LEVEL)
-                .attr("bms_bmsStatus.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bms_bmsStatus.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bms_bmsStatus.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.designCap", const.MAIN_DESIGN_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.fullCap", const.MAIN_FULL_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.remainCap", const.MAIN_REMAIN_CAPACITY, False),
-
-            LevelSensorEntity(client, self, "bms_emsStatus.f32LcdSoc", const.COMBINED_BATTERY_LEVEL),
-
-            ChargingStateSensorEntity(client, self, "bms_emsStatus.chgState", const.BATTERY_CHARGING_STATE),
-
-            InWattsSensorEntity(client, self, "bms_bmsStatus.inWatts", const.TOTAL_IN_POWER),
-            OutWattsSensorEntity(client, self, "bms_bmsStatus.outWatts", const.TOTAL_OUT_POWER),
-
+            LevelSensorEntity(
+                client, self, "bms_bmsStatus.soc", const.MAIN_BATTERY_LEVEL
+            )
+            .attr("bms_bmsStatus.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bms_bmsStatus.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bms_bmsStatus.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bms_bmsStatus.designCap",
+                const.MAIN_DESIGN_CAPACITY,
+                False,
+            ),
+            CapacitySensorEntity(
+                client, self, "bms_bmsStatus.fullCap", const.MAIN_FULL_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bms_bmsStatus.remainCap",
+                const.MAIN_REMAIN_CAPACITY,
+                False,
+            ),
+            LevelSensorEntity(
+                client, self, "bms_emsStatus.f32LcdSoc", const.COMBINED_BATTERY_LEVEL
+            ),
+            ChargingStateSensorEntity(
+                client, self, "bms_emsStatus.chgState", const.BATTERY_CHARGING_STATE
+            ),
+            InWattsSensorEntity(
+                client, self, "bms_bmsStatus.inWatts", const.TOTAL_IN_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "bms_bmsStatus.outWatts", const.TOTAL_OUT_POWER
+            ),
             OutWattsSensorEntity(client, self, "pd.motorWat", "Motor Power"),
-
-            RemainSensorEntity(client, self, "bms_emsStatus.chgRemain", const.CHARGE_REMAINING_TIME),
-            RemainSensorEntity(client, self, "bms_emsStatus.dsgRemain", const.DISCHARGE_REMAINING_TIME),
-
+            RemainSensorEntity(
+                client, self, "bms_emsStatus.chgRemain", const.CHARGE_REMAINING_TIME
+            ),
+            RemainSensorEntity(
+                client, self, "bms_emsStatus.dsgRemain", const.DISCHARGE_REMAINING_TIME
+            ),
             CyclesSensorEntity(client, self, "bms_bmsStatus.cycles", const.CYCLES),
-
             TempSensorEntity(client, self, "bms_bmsStatus.tmp", const.BATTERY_TEMP)
-                .attr("bms_bmsStatus.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-                .attr("bms_bmsStatus.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            TempSensorEntity(client, self, "bms_bmsStatus.minCellTmp", const.MIN_CELL_TEMP, False),
-            TempSensorEntity(client, self, "bms_bmsStatus.maxCellTmp", const.MAX_CELL_TEMP, False),
-
-            VoltSensorEntity(client, self, "bms_bmsStatus.vol", const.BATTERY_VOLT, False)
-                .attr("bms_bmsStatus.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
-                .attr("bms_bmsStatus.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            MilliVoltSensorEntity(client, self, "bms_bmsStatus.minCellVol", const.MIN_CELL_VOLT, False),
-            MilliVoltSensorEntity(client, self, "bms_bmsStatus.maxCellVol", const.MAX_CELL_VOLT, False),
-
-            MiscBinarySensorEntity(client,self,"pd.batFlag", "Battery Present"),
-
-            MiscSensorEntity(client, self, "pd.xt60InState", "XT60 State"),  
-
-            #Fridge Entities
+            .attr("bms_bmsStatus.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+            .attr("bms_bmsStatus.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+            TempSensorEntity(
+                client, self, "bms_bmsStatus.minCellTmp", const.MIN_CELL_TEMP, False
+            ),
+            TempSensorEntity(
+                client, self, "bms_bmsStatus.maxCellTmp", const.MAX_CELL_TEMP, False
+            ),
+            VoltSensorEntity(
+                client, self, "bms_bmsStatus.vol", const.BATTERY_VOLT, False
+            )
+            .attr("bms_bmsStatus.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
+            .attr("bms_bmsStatus.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
+            MilliVoltSensorEntity(
+                client, self, "bms_bmsStatus.minCellVol", const.MIN_CELL_VOLT, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bms_bmsStatus.maxCellVol", const.MAX_CELL_VOLT, False
+            ),
+            MiscBinarySensorEntity(client, self, "pd.batFlag", "Battery Present"),
+            MiscSensorEntity(client, self, "pd.xt60InState", "XT60 State"),
+            # Fridge Entities
             FanSensorEntity(client, self, "bms_emsStatus.fanLvl", "Fan Level"),
-
-            DecicelsiusSensorEntity(client, self, "pd.ambientTmp", "Ambient Temperature"),
-            DecicelsiusSensorEntity(client, self, "pd.exhaustTmp", "Exhaust Temperature"),
+            DecicelsiusSensorEntity(
+                client, self, "pd.ambientTmp", "Ambient Temperature"
+            ),
+            DecicelsiusSensorEntity(
+                client, self, "pd.exhaustTmp", "Exhaust Temperature"
+            ),
             DecicelsiusSensorEntity(client, self, "pd.tempWater", "Water Temperature"),
-            DecicelsiusSensorEntity(client, self, "pd.tmpL", "Left Temperature"),            
-            DecicelsiusSensorEntity(client, self, "pd.tmpR", "Right Temperature"),            
-
-            MiscBinarySensorEntity(client, self,"pd.flagTwoZone","Dual Zone Mode"),
-
+            DecicelsiusSensorEntity(client, self, "pd.tmpL", "Left Temperature"),
+            DecicelsiusSensorEntity(client, self, "pd.tmpR", "Right Temperature"),
+            MiscBinarySensorEntity(client, self, "pd.flagTwoZone", "Dual Zone Mode"),
             SecondsRemainSensorEntity(client, self, "pd.iceTm", "Ice Time Remain"),
             LevelSensorEntity(client, self, "pd.icePercent", "Ice Percentage"),
-
-            MiscSensorEntity(client, self, "pd.iceMkMode", "Ice Make Mode"), 
-
-            MiscBinarySensorEntity(client, self,"pd.iceAlert","Ice Alert"),
-            MiscBinarySensorEntity(client,self, "pd.waterLine","Ice Water Level OK"),
-
-            QuotaStatusSensorEntity(client, self)
-
+            MiscSensorEntity(client, self, "pd.iceMkMode", "Ice Make Mode"),
+            MiscBinarySensorEntity(client, self, "pd.iceAlert", "Ice Alert"),
+            MiscBinarySensorEntity(client, self, "pd.waterLine", "Ice Water Level OK"),
+            QuotaStatusSensorEntity(client, self),
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return [
-            SetTempEntity(client, self,"pd.tmpLSet", "Left Set Temperature",-25, 10,
-                                  lambda value, params: {"moduleType": 1, "operateType": "temp",
-                                                 "params": {"tmpM": int(params.get("pd.tmpMSet", 0)),
-                                                            "tmpL": int(value),
-                                                            "tmpR": int(params.get("pd.tmpRSet", 0))}}),
-            
-            SetTempEntity(client, self, "pd.tmpMSet", "Combined Set Temperature",-25, 10,
-                                  lambda value, params: {"moduleType": 1, "operateType": "temp",
-                                                 "params": {"tmpM": int(value),
-                                                            "tmpL": int(params.get("pd.tmpLSet", 0)),
-                                                            "tmpR": int(params.get("pd.tmpRSet", 0))}}),
-
-            SetTempEntity(client, self,"pd.tmpRSet", "Right Set Temperature",-25, 10,
-                                  lambda value, params: {"moduleType": 1, "operateType": "temp",
-                                                 "params": {"tmpM": int(params.get("pd.tmpMSet", 0)),
-                                                            "tmpL": int(params.get("pd.tmpLSet", 0)),
-                                                            "tmpR": int(value)}}),                                                                                                                        
-
+            SetTempEntity(
+                client,
+                self,
+                "pd.tmpLSet",
+                "Left Set Temperature",
+                -25,
+                10,
+                lambda value, params: {
+                    "moduleType": 1,
+                    "operateType": "temp",
+                    "params": {
+                        "tmpM": int(params.get("pd.tmpMSet", 0)),
+                        "tmpL": int(value),
+                        "tmpR": int(params.get("pd.tmpRSet", 0)),
+                    },
+                },
+            ),
+            SetTempEntity(
+                client,
+                self,
+                "pd.tmpMSet",
+                "Combined Set Temperature",
+                -25,
+                10,
+                lambda value, params: {
+                    "moduleType": 1,
+                    "operateType": "temp",
+                    "params": {
+                        "tmpM": int(value),
+                        "tmpL": int(params.get("pd.tmpLSet", 0)),
+                        "tmpR": int(params.get("pd.tmpRSet", 0)),
+                    },
+                },
+            ),
+            SetTempEntity(
+                client,
+                self,
+                "pd.tmpRSet",
+                "Right Set Temperature",
+                -25,
+                10,
+                lambda value, params: {
+                    "moduleType": 1,
+                    "operateType": "temp",
+                    "params": {
+                        "tmpM": int(params.get("pd.tmpMSet", 0)),
+                        "tmpL": int(params.get("pd.tmpLSet", 0)),
+                        "tmpR": int(value),
+                    },
+                },
+            ),
         ]
 
     def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
         return [
-            InvertedBeeperEntity(client, self, "pd.beepEn", const.BEEPER,
-                         lambda value: {"moduleType": 1, "operateType": "beepEn", "params": {"flag": value}}),
-
-            EnabledEntity(client, self, "pd.coolMode", "Eco Mode",
-                          lambda value: {"moduleType": 1, "operateType": "ecoMode", "params": {"mode": value}}),                         
-
-            #power parameter is inverted for some reason
-            EnabledEntity(client, self, "pd.pwrState", "Power",
-                          lambda value: {"moduleType": 1, "operateType": "powerOff", "params": {"enable": value}}),                         
-
+            InvertedBeeperEntity(
+                client,
+                self,
+                "pd.beepEn",
+                const.BEEPER,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "beepEn",
+                    "params": {"flag": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.coolMode",
+                "Eco Mode",
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "ecoMode",
+                    "params": {"mode": value},
+                },
+            ),
+            # power parameter is inverted for some reason
+            EnabledEntity(
+                client,
+                self,
+                "pd.pwrState",
+                "Power",
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "powerOff",
+                    "params": {"enable": value},
+                },
+            ),
         ]
-    
+
     def buttons(self, client: EcoflowApiClient) -> list[BaseButtonEntity]:
         return [
-            EnabledButtonEntity(client, self, "smlice", "Make Small Ice", lambda value: {"moduleType": 1, "operateType": "iceMake", "params": {"enable": 1, "iceShape": 0}}),
-            EnabledButtonEntity(client, self, "lrgice", "Make Large Ice", lambda value: {"moduleType": 1, "operateType": "iceMake", "params": {"enable": 1, "iceShape": 1}}),
-            EnabledButtonEntity(client, self, "deice", "Detach Ice", lambda value: {"moduleType": 1, "operateType": "deIce", "params": {"enable": 1}})
-
-        ]    
-        
+            EnabledButtonEntity(
+                client,
+                self,
+                "smlice",
+                "Make Small Ice",
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "iceMake",
+                    "params": {"enable": 1, "iceShape": 0},
+                },
+            ),
+            EnabledButtonEntity(
+                client,
+                self,
+                "lrgice",
+                "Make Large Ice",
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "iceMake",
+                    "params": {"enable": 1, "iceShape": 1},
+                },
+            ),
+            EnabledButtonEntity(
+                client,
+                self,
+                "deice",
+                "Detach Ice",
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "deIce",
+                    "params": {"enable": 1},
+                },
+            ),
+        ]
 
     def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:
-        return [
-
-        ]
+        return []

--- a/custom_components/ecoflow_cloud/devices/internal/river2.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river2.py
@@ -1,15 +1,48 @@
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import const, BaseDevice
-from custom_components.ecoflow_cloud.devices.const import ATTR_DESIGN_CAPACITY, ATTR_FULL_CAPACITY, ATTR_REMAIN_CAPACITY, BATTERY_CHARGING_STATE, \
-    MAIN_DESIGN_CAPACITY, MAIN_FULL_CAPACITY, MAIN_REMAIN_CAPACITY
-from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, BaseSelectEntity
-from custom_components.ecoflow_cloud.number import ChargingPowerEntity, MaxBatteryLevelEntity, MinBatteryLevelEntity, BatteryBackupLevel
-from custom_components.ecoflow_cloud.select import DictSelectEntity, TimeoutDictSelectEntity
-from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, RemainSensorEntity, TempSensorEntity, \
-    CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity, VoltSensorEntity, InMilliampSensorEntity, \
-    InVoltSensorEntity, MilliVoltSensorEntity, InMilliVoltSensorEntity, \
-    OutMilliVoltSensorEntity, ChargingStateSensorEntity, CapacitySensorEntity, StatusSensorEntity, \
-    QuotaStatusSensorEntity
+from custom_components.ecoflow_cloud.devices.const import (
+    ATTR_DESIGN_CAPACITY,
+    ATTR_FULL_CAPACITY,
+    ATTR_REMAIN_CAPACITY,
+    BATTERY_CHARGING_STATE,
+    MAIN_DESIGN_CAPACITY,
+    MAIN_FULL_CAPACITY,
+    MAIN_REMAIN_CAPACITY,
+)
+from custom_components.ecoflow_cloud.entities import (
+    BaseSensorEntity,
+    BaseNumberEntity,
+    BaseSwitchEntity,
+    BaseSelectEntity,
+)
+from custom_components.ecoflow_cloud.number import (
+    ChargingPowerEntity,
+    MaxBatteryLevelEntity,
+    MinBatteryLevelEntity,
+    BatteryBackupLevel,
+)
+from custom_components.ecoflow_cloud.select import (
+    DictSelectEntity,
+    TimeoutDictSelectEntity,
+)
+from custom_components.ecoflow_cloud.sensor import (
+    LevelSensorEntity,
+    RemainSensorEntity,
+    TempSensorEntity,
+    CyclesSensorEntity,
+    InWattsSensorEntity,
+    OutWattsSensorEntity,
+    VoltSensorEntity,
+    InMilliampSensorEntity,
+    InVoltSensorEntity,
+    MilliVoltSensorEntity,
+    InMilliVoltSensorEntity,
+    OutMilliVoltSensorEntity,
+    ChargingStateSensorEntity,
+    CapacitySensorEntity,
+    StatusSensorEntity,
+    QuotaStatusSensorEntity,
+)
 from custom_components.ecoflow_cloud.switch import EnabledEntity
 
 
@@ -21,138 +54,283 @@ class River2(BaseDevice):
 
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
-            LevelSensorEntity(client, self, "bms_bmsStatus.soc", const.MAIN_BATTERY_LEVEL)
-                .attr("bms_bmsStatus.designCap", ATTR_DESIGN_CAPACITY, 0)
-                .attr("bms_bmsStatus.fullCap", ATTR_FULL_CAPACITY, 0)
-                .attr("bms_bmsStatus.remainCap", ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.designCap", MAIN_DESIGN_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.fullCap", MAIN_FULL_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.remainCap", MAIN_REMAIN_CAPACITY, False),
-
+            LevelSensorEntity(
+                client, self, "bms_bmsStatus.soc", const.MAIN_BATTERY_LEVEL
+            )
+            .attr("bms_bmsStatus.designCap", ATTR_DESIGN_CAPACITY, 0)
+            .attr("bms_bmsStatus.fullCap", ATTR_FULL_CAPACITY, 0)
+            .attr("bms_bmsStatus.remainCap", ATTR_REMAIN_CAPACITY, 0),
+            CapacitySensorEntity(
+                client, self, "bms_bmsStatus.designCap", MAIN_DESIGN_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bms_bmsStatus.fullCap", MAIN_FULL_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bms_bmsStatus.remainCap", MAIN_REMAIN_CAPACITY, False
+            ),
             LevelSensorEntity(client, self, "bms_bmsStatus.soh", const.SOH),
-
-            LevelSensorEntity(client, self, "bms_emsStatus.lcdShowSoc", const.COMBINED_BATTERY_LEVEL),
-
-            ChargingStateSensorEntity(client, self, "bms_emsStatus.chgState", BATTERY_CHARGING_STATE),
-
+            LevelSensorEntity(
+                client, self, "bms_emsStatus.lcdShowSoc", const.COMBINED_BATTERY_LEVEL
+            ),
+            ChargingStateSensorEntity(
+                client, self, "bms_emsStatus.chgState", BATTERY_CHARGING_STATE
+            ),
             InWattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             OutWattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
-
             InMilliampSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
             InVoltSensorEntity(client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
-
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
-
             InMilliVoltSensorEntity(client, self, "inv.acInVol", const.AC_IN_VOLT),
             OutMilliVoltSensorEntity(client, self, "inv.invOutVol", const.AC_OUT_VOLT),
-
-            InWattsSensorEntity(client, self, "pd.typecChaWatts", const.TYPE_C_IN_POWER),
+            InWattsSensorEntity(
+                client, self, "pd.typecChaWatts", const.TYPE_C_IN_POWER
+            ),
             InWattsSensorEntity(client, self, "mppt.inWatts", const.SOLAR_IN_POWER),
-
-
             OutWattsSensorEntity(client, self, "pd.carWatts", const.DC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.typec1Watts", const.TYPEC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb1Watts", const.USB_OUT_POWER),
             # OutWattsSensorEntity(client, self, "pd.usb2Watts", const.USB_2_OUT_POWER),
-
-            RemainSensorEntity(client, self, "bms_emsStatus.chgRemainTime", const.CHARGE_REMAINING_TIME),
-            RemainSensorEntity(client, self, "bms_emsStatus.dsgRemainTime", const.DISCHARGE_REMAINING_TIME),
+            RemainSensorEntity(
+                client, self, "bms_emsStatus.chgRemainTime", const.CHARGE_REMAINING_TIME
+            ),
+            RemainSensorEntity(
+                client,
+                self,
+                "bms_emsStatus.dsgRemainTime",
+                const.DISCHARGE_REMAINING_TIME,
+            ),
             RemainSensorEntity(client, self, "pd.remainTime", const.REMAINING_TIME),
-
             TempSensorEntity(client, self, "inv.outTemp", "Inv Out Temperature"),
             CyclesSensorEntity(client, self, "bms_bmsStatus.cycles", const.CYCLES),
-
             TempSensorEntity(client, self, "bms_bmsStatus.temp", const.BATTERY_TEMP)
-                .attr("bms_bmsStatus.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-                .attr("bms_bmsStatus.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            TempSensorEntity(client, self, "bms_bmsStatus.minCellTemp", const.MIN_CELL_TEMP, False),
-            TempSensorEntity(client, self, "bms_bmsStatus.maxCellTemp", const.MAX_CELL_TEMP, False),
-
-            VoltSensorEntity(client, self, "bms_bmsStatus.vol", const.BATTERY_VOLT, False)
-                .attr("bms_bmsStatus.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
-                .attr("bms_bmsStatus.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            MilliVoltSensorEntity(client, self, "bms_bmsStatus.minCellVol", const.MIN_CELL_VOLT, False),
-            MilliVoltSensorEntity(client, self, "bms_bmsStatus.maxCellVol", const.MAX_CELL_VOLT, False),
-
+            .attr("bms_bmsStatus.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+            .attr("bms_bmsStatus.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+            TempSensorEntity(
+                client, self, "bms_bmsStatus.minCellTemp", const.MIN_CELL_TEMP, False
+            ),
+            TempSensorEntity(
+                client, self, "bms_bmsStatus.maxCellTemp", const.MAX_CELL_TEMP, False
+            ),
+            VoltSensorEntity(
+                client, self, "bms_bmsStatus.vol", const.BATTERY_VOLT, False
+            )
+            .attr("bms_bmsStatus.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
+            .attr("bms_bmsStatus.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
+            MilliVoltSensorEntity(
+                client, self, "bms_bmsStatus.minCellVol", const.MIN_CELL_VOLT, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bms_bmsStatus.maxCellVol", const.MAX_CELL_VOLT, False
+            ),
             self._status_sensor(client),
             # FanSensorEntity(client, self, "bms_emsStatus.fanLevel", "Fan Level"),
-
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return [
-            MaxBatteryLevelEntity(client, self, "bms_emsStatus.maxChargeSoc", const.MAX_CHARGE_LEVEL, 50, 100,
-                                  lambda value: {"moduleType": 2, "operateType": "upsConfig",
-                                                 "params": {"maxChgSoc": int(value)}}),
-
-            MinBatteryLevelEntity(client, self, "bms_emsStatus.minDsgSoc", const.MIN_DISCHARGE_LEVEL, 0, 30,
-                                  lambda value: {"moduleType": 2, "operateType": "dsgCfg",
-                                                 "params": {"minDsgSoc": int(value)}}),
-
-            ChargingPowerEntity(client, self, "mppt.cfgChgWatts", const.AC_CHARGING_POWER, 100, 360,
-                                lambda value: {"moduleType": 5, "operateType": "acChgCfg",
-                                               "params": {"chgWatts": int(value), "chgPauseFlag": 255}}),
-
-            BatteryBackupLevel(client, self,"pd.bpPowerSoc", const.BACKUP_RESERVE_LEVEL, 5, 100,
-                               "bms_emsStatus.minDsgSoc", "bms_emsStatus.maxChargeSoc",
-                               lambda value: {"moduleType": 1, "operateType": "watthConfig",
-                                              "params": {"isConfig": 1,
-                                                         "bpPowerSoc": int(value),
-                                                         "minDsgSoc": 0,
-                                                         "minChgSoc": 0}}),
+            MaxBatteryLevelEntity(
+                client,
+                self,
+                "bms_emsStatus.maxChargeSoc",
+                const.MAX_CHARGE_LEVEL,
+                50,
+                100,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "upsConfig",
+                    "params": {"maxChgSoc": int(value)},
+                },
+            ),
+            MinBatteryLevelEntity(
+                client,
+                self,
+                "bms_emsStatus.minDsgSoc",
+                const.MIN_DISCHARGE_LEVEL,
+                0,
+                30,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "dsgCfg",
+                    "params": {"minDsgSoc": int(value)},
+                },
+            ),
+            ChargingPowerEntity(
+                client,
+                self,
+                "mppt.cfgChgWatts",
+                const.AC_CHARGING_POWER,
+                100,
+                360,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "acChgCfg",
+                    "params": {"chgWatts": int(value), "chgPauseFlag": 255},
+                },
+            ),
+            BatteryBackupLevel(
+                client,
+                self,
+                "pd.bpPowerSoc",
+                const.BACKUP_RESERVE_LEVEL,
+                5,
+                100,
+                "bms_emsStatus.minDsgSoc",
+                "bms_emsStatus.maxChargeSoc",
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "watthConfig",
+                    "params": {
+                        "isConfig": 1,
+                        "bpPowerSoc": int(value),
+                        "minDsgSoc": 0,
+                        "minChgSoc": 0,
+                    },
+                },
+            ),
         ]
 
     def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
         return [
-            EnabledEntity(client, self, "mppt.cfgAcEnabled", const.AC_ENABLED,
-                          lambda value: {"moduleType": 5, "operateType": "acOutCfg",
-                                         "params": {"enabled": value, "out_voltage": -1, "out_freq": 255,
-                                                    "xboost": 255}}),
-
-            EnabledEntity(client, self, "pd.acAutoOutConfig", const.AC_ALWAYS_ENABLED,
-                          lambda value, params: {"moduleType": 1, "operateType": "acAutoOutConfig",
-                                                 "params": {"acAutoOutConfig": value,
-                                                            "minAcOutSoc": int(params.get("bms_emsStatus.minDsgSoc", 0)) + 5}}
-                          ),
-
-            EnabledEntity(client, self, "mppt.cfgAcXboost", const.XBOOST_ENABLED,
-                          lambda value: {"moduleType": 5, "operateType": "acOutCfg",
-                                         "params": {"enabled": 255, "out_voltage": -1, "out_freq": 255,
-                                                    "xboost": value}}),
-
-            EnabledEntity(client, self, "pd.carState", const.DC_ENABLED,
-                          lambda value: {"moduleType": 5, "operateType": "mpptCar", "params": {"enabled": value}}),
-
-            EnabledEntity(client, self, "pd.watchIsConfig", const.BP_ENABLED,
-                          lambda value, params: {"moduleType": 1, "operateType": "watthConfig",
-                                                 "params": {"isConfig": value,
-                                                            "bpPowerSoc": value * 50,
-                                                            "minDsgSoc": 0,
-                                                            "minChgSoc": 0}})
+            EnabledEntity(
+                client,
+                self,
+                "mppt.cfgAcEnabled",
+                const.AC_ENABLED,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "acOutCfg",
+                    "params": {
+                        "enabled": value,
+                        "out_voltage": -1,
+                        "out_freq": 255,
+                        "xboost": 255,
+                    },
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.acAutoOutConfig",
+                const.AC_ALWAYS_ENABLED,
+                lambda value, params: {
+                    "moduleType": 1,
+                    "operateType": "acAutoOutConfig",
+                    "params": {
+                        "acAutoOutConfig": value,
+                        "minAcOutSoc": int(params.get("bms_emsStatus.minDsgSoc", 0))
+                        + 5,
+                    },
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "mppt.cfgAcXboost",
+                const.XBOOST_ENABLED,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "acOutCfg",
+                    "params": {
+                        "enabled": 255,
+                        "out_voltage": -1,
+                        "out_freq": 255,
+                        "xboost": value,
+                    },
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.carState",
+                const.DC_ENABLED,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "mpptCar",
+                    "params": {"enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.watchIsConfig",
+                const.BP_ENABLED,
+                lambda value, params: {
+                    "moduleType": 1,
+                    "operateType": "watthConfig",
+                    "params": {
+                        "isConfig": value,
+                        "bpPowerSoc": value * 50,
+                        "minDsgSoc": 0,
+                        "minChgSoc": 0,
+                    },
+                },
+            ),
         ]
 
     def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:
         return [
-            DictSelectEntity(client, self, "mppt.dcChgCurrent", const.DC_CHARGE_CURRENT, const.DC_CHARGE_CURRENT_OPTIONS,
-                             lambda value: {"moduleType": 5, "operateType": "dcChgCfg",
-                                            "params": {"dcChgCfg": value}}),
-
-            DictSelectEntity(client, self, "mppt.cfgChgType", const.DC_MODE, const.DC_MODE_OPTIONS,
-                             lambda value: {"moduleType": 5, "operateType": "chaType",
-                                            "params": {"chaType": value}}),
-
-            TimeoutDictSelectEntity(client, self, "mppt.scrStandbyMin", const.SCREEN_TIMEOUT, const.SCREEN_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 5, "operateType": "lcdCfg",
-                                                   "params": {"brighLevel": 255, "delayOff": value}}),
-
-            TimeoutDictSelectEntity(client, self, "mppt.powStandbyMin", const.UNIT_TIMEOUT, const.UNIT_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 5, "operateType": "standby",
-                                                   "params": {"standbyMins": value}}),
-
-            TimeoutDictSelectEntity(client, self, "mppt.acStandbyMins", const.AC_TIMEOUT, const.AC_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 5, "operateType": "acStandby",
-                                                   "params": {"standbyMins": value}})
+            DictSelectEntity(
+                client,
+                self,
+                "mppt.dcChgCurrent",
+                const.DC_CHARGE_CURRENT,
+                const.DC_CHARGE_CURRENT_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "dcChgCfg",
+                    "params": {"dcChgCfg": value},
+                },
+            ),
+            DictSelectEntity(
+                client,
+                self,
+                "mppt.cfgChgType",
+                const.DC_MODE,
+                const.DC_MODE_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "chaType",
+                    "params": {"chaType": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "mppt.scrStandbyMin",
+                const.SCREEN_TIMEOUT,
+                const.SCREEN_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "lcdCfg",
+                    "params": {"brighLevel": 255, "delayOff": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "mppt.powStandbyMin",
+                const.UNIT_TIMEOUT,
+                const.UNIT_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "standby",
+                    "params": {"standbyMins": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "mppt.acStandbyMins",
+                const.AC_TIMEOUT,
+                const.AC_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "acStandby",
+                    "params": {"standbyMins": value},
+                },
+            ),
         ]
 
     def _status_sensor(self, client: EcoflowApiClient) -> StatusSensorEntity:

--- a/custom_components/ecoflow_cloud/devices/internal/river2_max.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river2_max.py
@@ -1,15 +1,48 @@
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import const, BaseDevice
-from custom_components.ecoflow_cloud.devices.const import ATTR_DESIGN_CAPACITY, ATTR_FULL_CAPACITY, ATTR_REMAIN_CAPACITY, BATTERY_CHARGING_STATE, \
-    MAIN_DESIGN_CAPACITY, MAIN_FULL_CAPACITY, MAIN_REMAIN_CAPACITY
-from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, BaseSelectEntity
-from custom_components.ecoflow_cloud.number import ChargingPowerEntity, MaxBatteryLevelEntity, MinBatteryLevelEntity, BatteryBackupLevel
-from custom_components.ecoflow_cloud.select import DictSelectEntity, TimeoutDictSelectEntity
-from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, RemainSensorEntity, TempSensorEntity, \
-    CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity, VoltSensorEntity, InMilliampSensorEntity, \
-    InVoltSensorEntity, MilliVoltSensorEntity, InMilliVoltSensorEntity, \
-    OutMilliVoltSensorEntity, ChargingStateSensorEntity, CapacitySensorEntity, StatusSensorEntity, \
-    QuotaStatusSensorEntity
+from custom_components.ecoflow_cloud.devices.const import (
+    ATTR_DESIGN_CAPACITY,
+    ATTR_FULL_CAPACITY,
+    ATTR_REMAIN_CAPACITY,
+    BATTERY_CHARGING_STATE,
+    MAIN_DESIGN_CAPACITY,
+    MAIN_FULL_CAPACITY,
+    MAIN_REMAIN_CAPACITY,
+)
+from custom_components.ecoflow_cloud.entities import (
+    BaseSensorEntity,
+    BaseNumberEntity,
+    BaseSwitchEntity,
+    BaseSelectEntity,
+)
+from custom_components.ecoflow_cloud.number import (
+    ChargingPowerEntity,
+    MaxBatteryLevelEntity,
+    MinBatteryLevelEntity,
+    BatteryBackupLevel,
+)
+from custom_components.ecoflow_cloud.select import (
+    DictSelectEntity,
+    TimeoutDictSelectEntity,
+)
+from custom_components.ecoflow_cloud.sensor import (
+    LevelSensorEntity,
+    RemainSensorEntity,
+    TempSensorEntity,
+    CyclesSensorEntity,
+    InWattsSensorEntity,
+    OutWattsSensorEntity,
+    VoltSensorEntity,
+    InMilliampSensorEntity,
+    InVoltSensorEntity,
+    MilliVoltSensorEntity,
+    InMilliVoltSensorEntity,
+    OutMilliVoltSensorEntity,
+    ChargingStateSensorEntity,
+    CapacitySensorEntity,
+    StatusSensorEntity,
+    QuotaStatusSensorEntity,
+)
 from custom_components.ecoflow_cloud.switch import EnabledEntity
 
 
@@ -21,138 +54,283 @@ class River2Max(BaseDevice):
 
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
-            LevelSensorEntity(client, self, "bms_bmsStatus.soc", const.MAIN_BATTERY_LEVEL)
-                .attr("bms_bmsStatus.designCap", ATTR_DESIGN_CAPACITY, 0)
-                .attr("bms_bmsStatus.fullCap", ATTR_FULL_CAPACITY, 0)
-                .attr("bms_bmsStatus.remainCap", ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.designCap", MAIN_DESIGN_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.fullCap", MAIN_FULL_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.remainCap", MAIN_REMAIN_CAPACITY, False),
-
+            LevelSensorEntity(
+                client, self, "bms_bmsStatus.soc", const.MAIN_BATTERY_LEVEL
+            )
+            .attr("bms_bmsStatus.designCap", ATTR_DESIGN_CAPACITY, 0)
+            .attr("bms_bmsStatus.fullCap", ATTR_FULL_CAPACITY, 0)
+            .attr("bms_bmsStatus.remainCap", ATTR_REMAIN_CAPACITY, 0),
+            CapacitySensorEntity(
+                client, self, "bms_bmsStatus.designCap", MAIN_DESIGN_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bms_bmsStatus.fullCap", MAIN_FULL_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bms_bmsStatus.remainCap", MAIN_REMAIN_CAPACITY, False
+            ),
             LevelSensorEntity(client, self, "bms_bmsStatus.soh", const.SOH),
-
-            LevelSensorEntity(client, self, "bms_emsStatus.lcdShowSoc", const.COMBINED_BATTERY_LEVEL),
-
-            ChargingStateSensorEntity(client, self, "bms_emsStatus.chgState", BATTERY_CHARGING_STATE),
-
+            LevelSensorEntity(
+                client, self, "bms_emsStatus.lcdShowSoc", const.COMBINED_BATTERY_LEVEL
+            ),
+            ChargingStateSensorEntity(
+                client, self, "bms_emsStatus.chgState", BATTERY_CHARGING_STATE
+            ),
             InWattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             OutWattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
-
             InMilliampSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
             InVoltSensorEntity(client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
-
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
-
             InMilliVoltSensorEntity(client, self, "inv.acInVol", const.AC_IN_VOLT),
             OutMilliVoltSensorEntity(client, self, "inv.invOutVol", const.AC_OUT_VOLT),
-
-            InWattsSensorEntity(client, self, "pd.typecChaWatts", const.TYPE_C_IN_POWER),
+            InWattsSensorEntity(
+                client, self, "pd.typecChaWatts", const.TYPE_C_IN_POWER
+            ),
             InWattsSensorEntity(client, self, "mppt.inWatts", const.SOLAR_IN_POWER),
-
-
             OutWattsSensorEntity(client, self, "pd.carWatts", const.DC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.typec1Watts", const.TYPEC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb1Watts", const.USB_OUT_POWER),
             # OutWattsSensorEntity(client, self, "pd.usb2Watts", const.USB_2_OUT_POWER),
-
-            RemainSensorEntity(client, self, "bms_emsStatus.chgRemainTime", const.CHARGE_REMAINING_TIME),
-            RemainSensorEntity(client, self, "bms_emsStatus.dsgRemainTime", const.DISCHARGE_REMAINING_TIME),
+            RemainSensorEntity(
+                client, self, "bms_emsStatus.chgRemainTime", const.CHARGE_REMAINING_TIME
+            ),
+            RemainSensorEntity(
+                client,
+                self,
+                "bms_emsStatus.dsgRemainTime",
+                const.DISCHARGE_REMAINING_TIME,
+            ),
             RemainSensorEntity(client, self, "pd.remainTime", const.REMAINING_TIME),
-
             TempSensorEntity(client, self, "inv.outTemp", "Inv Out Temperature"),
             CyclesSensorEntity(client, self, "bms_bmsStatus.cycles", const.CYCLES),
-
             TempSensorEntity(client, self, "bms_bmsStatus.temp", const.BATTERY_TEMP)
-                .attr("bms_bmsStatus.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-                .attr("bms_bmsStatus.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            TempSensorEntity(client, self, "bms_bmsStatus.minCellTemp", const.MIN_CELL_TEMP, False),
-            TempSensorEntity(client, self, "bms_bmsStatus.maxCellTemp", const.MAX_CELL_TEMP, False),
-
-            VoltSensorEntity(client, self, "bms_bmsStatus.vol", const.BATTERY_VOLT, False)
-                .attr("bms_bmsStatus.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
-                .attr("bms_bmsStatus.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            MilliVoltSensorEntity(client, self, "bms_bmsStatus.minCellVol", const.MIN_CELL_VOLT, False),
-            MilliVoltSensorEntity(client, self, "bms_bmsStatus.maxCellVol", const.MAX_CELL_VOLT, False),
-
+            .attr("bms_bmsStatus.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+            .attr("bms_bmsStatus.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+            TempSensorEntity(
+                client, self, "bms_bmsStatus.minCellTemp", const.MIN_CELL_TEMP, False
+            ),
+            TempSensorEntity(
+                client, self, "bms_bmsStatus.maxCellTemp", const.MAX_CELL_TEMP, False
+            ),
+            VoltSensorEntity(
+                client, self, "bms_bmsStatus.vol", const.BATTERY_VOLT, False
+            )
+            .attr("bms_bmsStatus.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
+            .attr("bms_bmsStatus.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
+            MilliVoltSensorEntity(
+                client, self, "bms_bmsStatus.minCellVol", const.MIN_CELL_VOLT, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bms_bmsStatus.maxCellVol", const.MAX_CELL_VOLT, False
+            ),
             self._status_sensor(client),
             # FanSensorEntity(client, self, "bms_emsStatus.fanLevel", "Fan Level"),
-
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return [
-            MaxBatteryLevelEntity(client, self, "bms_emsStatus.maxChargeSoc", const.MAX_CHARGE_LEVEL, 50, 100,
-                                  lambda value: {"moduleType": 2, "operateType": "upsConfig",
-                                                 "params": {"maxChgSoc": int(value)}}),
-
-            MinBatteryLevelEntity(client, self, "bms_emsStatus.minDsgSoc", const.MIN_DISCHARGE_LEVEL, 0, 30,
-                                  lambda value: {"moduleType": 2, "operateType": "dsgCfg",
-                                                 "params": {"minDsgSoc": int(value)}}),
-
-            ChargingPowerEntity(client, self, "mppt.cfgChgWatts", const.AC_CHARGING_POWER, 50, 660,
-                                lambda value: {"moduleType": 5, "operateType": "acChgCfg",
-                                               "params": {"chgWatts": int(value), "chgPauseFlag": 255}}),
-
-            BatteryBackupLevel(client, self,"pd.bpPowerSoc", const.BACKUP_RESERVE_LEVEL, 5, 100,
-                               "bms_emsStatus.minDsgSoc", "bms_emsStatus.maxChargeSoc",
-                               lambda value: {"moduleType": 1, "operateType": "watthConfig",
-                                              "params": {"isConfig": 1,
-                                                         "bpPowerSoc": int(value),
-                                                         "minDsgSoc": 0,
-                                                         "minChgSoc": 0}}),
+            MaxBatteryLevelEntity(
+                client,
+                self,
+                "bms_emsStatus.maxChargeSoc",
+                const.MAX_CHARGE_LEVEL,
+                50,
+                100,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "upsConfig",
+                    "params": {"maxChgSoc": int(value)},
+                },
+            ),
+            MinBatteryLevelEntity(
+                client,
+                self,
+                "bms_emsStatus.minDsgSoc",
+                const.MIN_DISCHARGE_LEVEL,
+                0,
+                30,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "dsgCfg",
+                    "params": {"minDsgSoc": int(value)},
+                },
+            ),
+            ChargingPowerEntity(
+                client,
+                self,
+                "mppt.cfgChgWatts",
+                const.AC_CHARGING_POWER,
+                50,
+                660,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "acChgCfg",
+                    "params": {"chgWatts": int(value), "chgPauseFlag": 255},
+                },
+            ),
+            BatteryBackupLevel(
+                client,
+                self,
+                "pd.bpPowerSoc",
+                const.BACKUP_RESERVE_LEVEL,
+                5,
+                100,
+                "bms_emsStatus.minDsgSoc",
+                "bms_emsStatus.maxChargeSoc",
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "watthConfig",
+                    "params": {
+                        "isConfig": 1,
+                        "bpPowerSoc": int(value),
+                        "minDsgSoc": 0,
+                        "minChgSoc": 0,
+                    },
+                },
+            ),
         ]
 
     def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
         return [
-            EnabledEntity(client, self, "mppt.cfgAcEnabled", const.AC_ENABLED,
-                          lambda value: {"moduleType": 5, "operateType": "acOutCfg",
-                                         "params": {"enabled": value, "out_voltage": -1, "out_freq": 255,
-                                                    "xboost": 255}}),
-
-            EnabledEntity(client, self, "pd.acAutoOutConfig", const.AC_ALWAYS_ENABLED,
-                          lambda value, params: {"moduleType": 1, "operateType": "acAutoOutConfig",
-                                                 "params": {"acAutoOutConfig": value,
-                                                            "minAcOutSoc": int(params.get("bms_emsStatus.minDsgSoc", 0)) + 5}}
-                          ),
-
-            EnabledEntity(client, self, "mppt.cfgAcXboost", const.XBOOST_ENABLED,
-                          lambda value: {"moduleType": 5, "operateType": "acOutCfg",
-                                         "params": {"enabled": 255, "out_voltage": -1, "out_freq": 255,
-                                                    "xboost": value}}),
-
-            EnabledEntity(client, self, "pd.carState", const.DC_ENABLED,
-                          lambda value: {"moduleType": 5, "operateType": "mpptCar", "params": {"enabled": value}}),
-
-            EnabledEntity(client, self, "pd.watchIsConfig", const.BP_ENABLED,
-                          lambda value, params: {"moduleType": 1, "operateType": "watthConfig",
-                                                 "params": {"isConfig": value,
-                                                            "bpPowerSoc": value * 50,
-                                                            "minDsgSoc": 0,
-                                                            "minChgSoc": 0}})
+            EnabledEntity(
+                client,
+                self,
+                "mppt.cfgAcEnabled",
+                const.AC_ENABLED,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "acOutCfg",
+                    "params": {
+                        "enabled": value,
+                        "out_voltage": -1,
+                        "out_freq": 255,
+                        "xboost": 255,
+                    },
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.acAutoOutConfig",
+                const.AC_ALWAYS_ENABLED,
+                lambda value, params: {
+                    "moduleType": 1,
+                    "operateType": "acAutoOutConfig",
+                    "params": {
+                        "acAutoOutConfig": value,
+                        "minAcOutSoc": int(params.get("bms_emsStatus.minDsgSoc", 0))
+                        + 5,
+                    },
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "mppt.cfgAcXboost",
+                const.XBOOST_ENABLED,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "acOutCfg",
+                    "params": {
+                        "enabled": 255,
+                        "out_voltage": -1,
+                        "out_freq": 255,
+                        "xboost": value,
+                    },
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.carState",
+                const.DC_ENABLED,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "mpptCar",
+                    "params": {"enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.watchIsConfig",
+                const.BP_ENABLED,
+                lambda value, params: {
+                    "moduleType": 1,
+                    "operateType": "watthConfig",
+                    "params": {
+                        "isConfig": value,
+                        "bpPowerSoc": value * 50,
+                        "minDsgSoc": 0,
+                        "minChgSoc": 0,
+                    },
+                },
+            ),
         ]
 
     def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:
         return [
-            DictSelectEntity(client, self, "mppt.dcChgCurrent", const.DC_CHARGE_CURRENT, const.DC_CHARGE_CURRENT_OPTIONS,
-                             lambda value: {"moduleType": 5, "operateType": "dcChgCfg",
-                                            "params": {"dcChgCfg": value}}),
-
-            DictSelectEntity(client, self, "mppt.cfgChgType", const.DC_MODE, const.DC_MODE_OPTIONS,
-                             lambda value: {"moduleType": 5, "operateType": "chaType",
-                                            "params": {"chaType": value}}),
-
-            TimeoutDictSelectEntity(client, self, "mppt.scrStandbyMin", const.SCREEN_TIMEOUT, const.SCREEN_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 5, "operateType": "lcdCfg",
-                                                   "params": {"brighLevel": 255, "delayOff": value}}),
-
-            TimeoutDictSelectEntity(client, self, "mppt.powStandbyMin", const.UNIT_TIMEOUT, const.UNIT_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 5, "operateType": "standby",
-                                                   "params": {"standbyMins": value}}),
-
-            TimeoutDictSelectEntity(client, self, "mppt.acStandbyMins", const.AC_TIMEOUT, const.AC_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 5, "operateType": "acStandby",
-                                                   "params": {"standbyMins": value}})
+            DictSelectEntity(
+                client,
+                self,
+                "mppt.dcChgCurrent",
+                const.DC_CHARGE_CURRENT,
+                const.DC_CHARGE_CURRENT_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "dcChgCfg",
+                    "params": {"dcChgCfg": value},
+                },
+            ),
+            DictSelectEntity(
+                client,
+                self,
+                "mppt.cfgChgType",
+                const.DC_MODE,
+                const.DC_MODE_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "chaType",
+                    "params": {"chaType": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "mppt.scrStandbyMin",
+                const.SCREEN_TIMEOUT,
+                const.SCREEN_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "lcdCfg",
+                    "params": {"brighLevel": 255, "delayOff": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "mppt.powStandbyMin",
+                const.UNIT_TIMEOUT,
+                const.UNIT_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "standby",
+                    "params": {"standbyMins": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "mppt.acStandbyMins",
+                const.AC_TIMEOUT,
+                const.AC_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "acStandby",
+                    "params": {"standbyMins": value},
+                },
+            ),
         ]
 
     def _status_sensor(self, client: EcoflowApiClient) -> StatusSensorEntity:

--- a/custom_components/ecoflow_cloud/devices/internal/river2_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river2_pro.py
@@ -1,12 +1,35 @@
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import const, BaseDevice
-from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, BaseSelectEntity
-from custom_components.ecoflow_cloud.number import ChargingPowerEntity, MaxBatteryLevelEntity, MinBatteryLevelEntity
-from custom_components.ecoflow_cloud.select import DictSelectEntity, TimeoutDictSelectEntity
-from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, RemainSensorEntity, TempSensorEntity, \
-    CyclesSensorEntity, InWattsSensorEntity, OutWattsSensorEntity, VoltSensorEntity, MilliVoltSensorEntity, \
-    InMilliVoltSensorEntity, OutMilliVoltSensorEntity, ChargingStateSensorEntity, \
-    CapacitySensorEntity, QuotaStatusSensorEntity
+from custom_components.ecoflow_cloud.entities import (
+    BaseSensorEntity,
+    BaseNumberEntity,
+    BaseSwitchEntity,
+    BaseSelectEntity,
+)
+from custom_components.ecoflow_cloud.number import (
+    ChargingPowerEntity,
+    MaxBatteryLevelEntity,
+    MinBatteryLevelEntity,
+)
+from custom_components.ecoflow_cloud.select import (
+    DictSelectEntity,
+    TimeoutDictSelectEntity,
+)
+from custom_components.ecoflow_cloud.sensor import (
+    LevelSensorEntity,
+    RemainSensorEntity,
+    TempSensorEntity,
+    CyclesSensorEntity,
+    InWattsSensorEntity,
+    OutWattsSensorEntity,
+    VoltSensorEntity,
+    MilliVoltSensorEntity,
+    InMilliVoltSensorEntity,
+    OutMilliVoltSensorEntity,
+    ChargingStateSensorEntity,
+    CapacitySensorEntity,
+    QuotaStatusSensorEntity,
+)
 from custom_components.ecoflow_cloud.switch import EnabledEntity
 
 
@@ -18,112 +41,236 @@ class River2Pro(BaseDevice):
 
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
-            LevelSensorEntity(client, self, "bms_bmsStatus.soc", const.MAIN_BATTERY_LEVEL)
-                .attr("bms_bmsStatus.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bms_bmsStatus.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bms_bmsStatus.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.designCap", const.MAIN_DESIGN_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.fullCap", const.MAIN_FULL_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bms_bmsStatus.remainCap", const.MAIN_REMAIN_CAPACITY, False),
-
+            LevelSensorEntity(
+                client, self, "bms_bmsStatus.soc", const.MAIN_BATTERY_LEVEL
+            )
+            .attr("bms_bmsStatus.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bms_bmsStatus.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bms_bmsStatus.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bms_bmsStatus.designCap",
+                const.MAIN_DESIGN_CAPACITY,
+                False,
+            ),
+            CapacitySensorEntity(
+                client, self, "bms_bmsStatus.fullCap", const.MAIN_FULL_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client,
+                self,
+                "bms_bmsStatus.remainCap",
+                const.MAIN_REMAIN_CAPACITY,
+                False,
+            ),
             LevelSensorEntity(client, self, "bms_bmsStatus.soh", const.SOH),
-            LevelSensorEntity(client, self, "bms_emsStatus.lcdShowSoc", const.COMBINED_BATTERY_LEVEL),
-
-            ChargingStateSensorEntity(client, self, "bms_emsStatus.chgState", const.BATTERY_CHARGING_STATE),
-
+            LevelSensorEntity(
+                client, self, "bms_emsStatus.lcdShowSoc", const.COMBINED_BATTERY_LEVEL
+            ),
+            ChargingStateSensorEntity(
+                client, self, "bms_emsStatus.chgState", const.BATTERY_CHARGING_STATE
+            ),
             InWattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             OutWattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
-
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
-
             InMilliVoltSensorEntity(client, self, "inv.acInVol", const.AC_IN_VOLT),
             OutMilliVoltSensorEntity(client, self, "inv.invOutVol", const.AC_OUT_VOLT),
-
-            InWattsSensorEntity(client, self, "pd.typecChaWatts", const.TYPE_C_IN_POWER),
+            InWattsSensorEntity(
+                client, self, "pd.typecChaWatts", const.TYPE_C_IN_POWER
+            ),
             InWattsSensorEntity(client, self, "mppt.inWatts", const.SOLAR_IN_POWER),
-
             OutWattsSensorEntity(client, self, "pd.carWatts", const.DC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.typec1Watts", const.TYPEC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb1Watts", const.USB_OUT_POWER),
             # OutWattsSensorEntity(client, self, "pd.usb2Watts", const.USB_2_OUT_POWER),
-
-            RemainSensorEntity(client, self, "bms_emsStatus.chgRemainTime", const.CHARGE_REMAINING_TIME),
-            RemainSensorEntity(client, self, "bms_emsStatus.dsgRemainTime", const.DISCHARGE_REMAINING_TIME),
+            RemainSensorEntity(
+                client, self, "bms_emsStatus.chgRemainTime", const.CHARGE_REMAINING_TIME
+            ),
+            RemainSensorEntity(
+                client,
+                self,
+                "bms_emsStatus.dsgRemainTime",
+                const.DISCHARGE_REMAINING_TIME,
+            ),
             RemainSensorEntity(client, self, "pd.remainTime", const.REMAINING_TIME),
-
-
             TempSensorEntity(client, self, "inv.outTemp", "Inv Out Temperature"),
             CyclesSensorEntity(client, self, "bms_bmsStatus.cycles", const.CYCLES),
-
             TempSensorEntity(client, self, "bms_bmsStatus.temp", const.BATTERY_TEMP)
-                .attr("bms_bmsStatus.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-                .attr("bms_bmsStatus.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            TempSensorEntity(client, self, "bms_bmsStatus.minCellTemp", const.MIN_CELL_TEMP, False),
-            TempSensorEntity(client, self, "bms_bmsStatus.maxCellTemp", const.MAX_CELL_TEMP, False),
-
-            VoltSensorEntity(client, self, "bms_bmsStatus.vol", const.BATTERY_VOLT, False)
-                .attr("bms_bmsStatus.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
-                .attr("bms_bmsStatus.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            MilliVoltSensorEntity(client, self, "bms_bmsStatus.minCellVol", const.MIN_CELL_VOLT, False),
-            MilliVoltSensorEntity(client, self, "bms_bmsStatus.maxCellVol", const.MAX_CELL_VOLT, False),
+            .attr("bms_bmsStatus.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+            .attr("bms_bmsStatus.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+            TempSensorEntity(
+                client, self, "bms_bmsStatus.minCellTemp", const.MIN_CELL_TEMP, False
+            ),
+            TempSensorEntity(
+                client, self, "bms_bmsStatus.maxCellTemp", const.MAX_CELL_TEMP, False
+            ),
+            VoltSensorEntity(
+                client, self, "bms_bmsStatus.vol", const.BATTERY_VOLT, False
+            )
+            .attr("bms_bmsStatus.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
+            .attr("bms_bmsStatus.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
+            MilliVoltSensorEntity(
+                client, self, "bms_bmsStatus.minCellVol", const.MIN_CELL_VOLT, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bms_bmsStatus.maxCellVol", const.MAX_CELL_VOLT, False
+            ),
             # FanSensorEntity(client, self, "bms_emsStatus.fanLevel", "Fan Level"),
-
-            QuotaStatusSensorEntity(client, self)
-
+            QuotaStatusSensorEntity(client, self),
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return [
-            MaxBatteryLevelEntity(client, self, "bms_emsStatus.maxChargeSoc", const.MAX_CHARGE_LEVEL, 50, 100,
-                                  lambda value: {"moduleType": 2, "operateType": "upsConfig",
-                                                 "params": {"maxChgSoc": int(value)}}),
-
-            MinBatteryLevelEntity(client, self, "bms_emsStatus.minDsgSoc", const.MIN_DISCHARGE_LEVEL, 0, 30,
-                                  lambda value: {"moduleType": 2, "operateType": "dsgCfg",
-                                                 "params": {"minDsgSoc": int(value)}}),
-
-            ChargingPowerEntity(client, self, "mppt.cfgChgWatts", const.AC_CHARGING_POWER, 100, 950,
-                                lambda value: {"moduleType": 5, "operateType": "acChgCfg",
-                                               "params": {"chgWatts": int(value), "chgPauseFlag": 255}}),
+            MaxBatteryLevelEntity(
+                client,
+                self,
+                "bms_emsStatus.maxChargeSoc",
+                const.MAX_CHARGE_LEVEL,
+                50,
+                100,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "upsConfig",
+                    "params": {"maxChgSoc": int(value)},
+                },
+            ),
+            MinBatteryLevelEntity(
+                client,
+                self,
+                "bms_emsStatus.minDsgSoc",
+                const.MIN_DISCHARGE_LEVEL,
+                0,
+                30,
+                lambda value: {
+                    "moduleType": 2,
+                    "operateType": "dsgCfg",
+                    "params": {"minDsgSoc": int(value)},
+                },
+            ),
+            ChargingPowerEntity(
+                client,
+                self,
+                "mppt.cfgChgWatts",
+                const.AC_CHARGING_POWER,
+                100,
+                950,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "acChgCfg",
+                    "params": {"chgWatts": int(value), "chgPauseFlag": 255},
+                },
+            ),
         ]
 
     def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
         return [
-            EnabledEntity(client, self, "mppt.cfgAcEnabled", const.AC_ENABLED,
-                          lambda value: {"moduleType": 5, "operateType": "acOutCfg",
-                                         "params": {"enabled": value, "out_voltage": -1, "out_freq": 255,
-                                                    "xboost": 255}}),
-
-            EnabledEntity(client, self, "mppt.cfgAcXboost", const.XBOOST_ENABLED,
-                          lambda value: {"moduleType": 5, "operateType": "acOutCfg",
-                                         "params": {"enabled": 255, "out_voltage": -1, "out_freq": 255,
-                                                    "xboost": value}}),
-
-            EnabledEntity(client, self, "pd.carState", const.DC_ENABLED,
-                          lambda value: {"moduleType": 5, "operateType": "mpptCar", "params": {"enabled": value}})
+            EnabledEntity(
+                client,
+                self,
+                "mppt.cfgAcEnabled",
+                const.AC_ENABLED,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "acOutCfg",
+                    "params": {
+                        "enabled": value,
+                        "out_voltage": -1,
+                        "out_freq": 255,
+                        "xboost": 255,
+                    },
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "mppt.cfgAcXboost",
+                const.XBOOST_ENABLED,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "acOutCfg",
+                    "params": {
+                        "enabled": 255,
+                        "out_voltage": -1,
+                        "out_freq": 255,
+                        "xboost": value,
+                    },
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.carState",
+                const.DC_ENABLED,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "mpptCar",
+                    "params": {"enabled": value},
+                },
+            ),
         ]
 
     def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:
         return [
-            DictSelectEntity(client, self, "mppt.dcChgCurrent", const.DC_CHARGE_CURRENT, const.DC_CHARGE_CURRENT_OPTIONS,
-                             lambda value: {"moduleType": 5, "operateType": "dcChgCfg",
-                                            "params": {"dcChgCfg": value}}),
-
-            DictSelectEntity(client, self, "mppt.cfgChgType", const.DC_MODE, const.DC_MODE_OPTIONS,
-                             lambda value: {"moduleType": 5, "operateType": "chaType",
-                                            "params": {"chaType": value}}),
-
-            TimeoutDictSelectEntity(client, self, "mppt.scrStandbyMin", const.SCREEN_TIMEOUT, const.SCREEN_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 5, "operateType": "lcdCfg",
-                                                   "params": {"brighLevel": 255, "delayOff": value}}),
-
-            TimeoutDictSelectEntity(client, self, "mppt.powStandbyMin", const.UNIT_TIMEOUT, const.UNIT_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 5, "operateType": "standby",
-                                                   "params": {"standbyMins": value}}),
-
-            TimeoutDictSelectEntity(client, self, "mppt.acStandbyMins", const.AC_TIMEOUT, const.AC_TIMEOUT_OPTIONS,
-                                    lambda value: {"moduleType": 5, "operateType": "acStandby",
-                                                   "params": {"standbyMins": value}})
+            DictSelectEntity(
+                client,
+                self,
+                "mppt.dcChgCurrent",
+                const.DC_CHARGE_CURRENT,
+                const.DC_CHARGE_CURRENT_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "dcChgCfg",
+                    "params": {"dcChgCfg": value},
+                },
+            ),
+            DictSelectEntity(
+                client,
+                self,
+                "mppt.cfgChgType",
+                const.DC_MODE,
+                const.DC_MODE_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "chaType",
+                    "params": {"chaType": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "mppt.scrStandbyMin",
+                const.SCREEN_TIMEOUT,
+                const.SCREEN_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "lcdCfg",
+                    "params": {"brighLevel": 255, "delayOff": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "mppt.powStandbyMin",
+                const.UNIT_TIMEOUT,
+                const.UNIT_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "standby",
+                    "params": {"standbyMins": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "mppt.acStandbyMins",
+                const.AC_TIMEOUT,
+                const.AC_TIMEOUT_OPTIONS,
+                lambda value: {
+                    "moduleType": 5,
+                    "operateType": "acStandby",
+                    "params": {"standbyMins": value},
+                },
+            ),
         ]
-

--- a/custom_components/ecoflow_cloud/devices/internal/river_max.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river_max.py
@@ -1,122 +1,269 @@
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import const, BaseDevice
-from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, BaseSelectEntity
+from custom_components.ecoflow_cloud.entities import (
+    BaseSensorEntity,
+    BaseNumberEntity,
+    BaseSwitchEntity,
+    BaseSelectEntity,
+)
 from custom_components.ecoflow_cloud.number import MaxBatteryLevelEntity
 from custom_components.ecoflow_cloud.select import TimeoutDictSelectEntity
-from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, \
-    TempSensorEntity, \
-    CyclesSensorEntity, InEnergySensorEntity, InWattsSensorEntity, OutEnergySensorEntity, OutWattsSensorEntity, \
-    InMilliampSensorEntity, MilliampSensorEntity, MilliVoltSensorEntity, InMilliVoltSensorEntity, \
-    OutMilliVoltSensorEntity, CapacitySensorEntity, QuotaStatusSensorEntity
-from custom_components.ecoflow_cloud.switch import EnabledEntity, BeeperEntity, FanModeEntity
+from custom_components.ecoflow_cloud.sensor import (
+    LevelSensorEntity,
+    WattsSensorEntity,
+    RemainSensorEntity,
+    TempSensorEntity,
+    CyclesSensorEntity,
+    InEnergySensorEntity,
+    InWattsSensorEntity,
+    OutEnergySensorEntity,
+    OutWattsSensorEntity,
+    InMilliampSensorEntity,
+    MilliampSensorEntity,
+    MilliVoltSensorEntity,
+    InMilliVoltSensorEntity,
+    OutMilliVoltSensorEntity,
+    CapacitySensorEntity,
+    QuotaStatusSensorEntity,
+)
+from custom_components.ecoflow_cloud.switch import (
+    EnabledEntity,
+    BeeperEntity,
+    FanModeEntity,
+)
 
 
 class RiverMax(BaseDevice):
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
             LevelSensorEntity(client, self, "bmsMaster.soc", const.MAIN_BATTERY_LEVEL)
-                .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bmsMaster.designCap", const.MAIN_DESIGN_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bmsMaster.fullCap", const.MAIN_FULL_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bmsMaster.remainCap", const.MAIN_REMAIN_CAPACITY, False),
-
+            .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            CapacitySensorEntity(
+                client, self, "bmsMaster.designCap", const.MAIN_DESIGN_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bmsMaster.fullCap", const.MAIN_FULL_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bmsMaster.remainCap", const.MAIN_REMAIN_CAPACITY, False
+            ),
             LevelSensorEntity(client, self, "pd.soc", const.COMBINED_BATTERY_LEVEL),
             WattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             WattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
-
             InMilliampSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
-            InMilliVoltSensorEntity(client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
-
+            InMilliVoltSensorEntity(
+                client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE
+            ),
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
-
             InMilliVoltSensorEntity(client, self, "inv.acInVol", const.AC_IN_VOLT),
             OutMilliVoltSensorEntity(client, self, "inv.invOutVol", const.AC_OUT_VOLT),
-
             OutWattsSensorEntity(client, self, "pd.carWatts", const.DC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.typecWatts", const.TYPEC_OUT_POWER),
             # disabled by default because they aren't terribly useful
             TempSensorEntity(client, self, "pd.carTemp", const.DC_CAR_OUT_TEMP, False),
             TempSensorEntity(client, self, "pd.typecTemp", const.USB_C_TEMP, False),
-
             OutWattsSensorEntity(client, self, "pd.usb1Watts", const.USB_1_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb2Watts", const.USB_2_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb3Watts", const.USB_3_OUT_POWER),
-
             RemainSensorEntity(client, self, "pd.remainTime", const.REMAINING_TIME),
             CyclesSensorEntity(client, self, "bmsMaster.cycles", const.CYCLES),
-
             TempSensorEntity(client, self, "bmsMaster.temp", const.BATTERY_TEMP)
-                .attr("bmsMaster.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-                .attr("bmsMaster.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            TempSensorEntity(client, self, "bmsMaster.minCellTemp", const.MIN_CELL_TEMP, False),
-            TempSensorEntity(client, self, "bmsMaster.maxCellTemp", const.MAX_CELL_TEMP, False),
-
-            MilliampSensorEntity(client, self, "bmsMaster.amp", const.BATTERY_AMP, False),
-            MilliVoltSensorEntity(client, self, "bmsMaster.vol", const.BATTERY_VOLT, False)
-                .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
-                .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            MilliVoltSensorEntity(client, self, "bmsMaster.minCellVol", const.MIN_CELL_VOLT, False),
-            MilliVoltSensorEntity(client, self, "bmsMaster.maxCellVol", const.MAX_CELL_VOLT, False),
-
+            .attr("bmsMaster.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+            .attr("bmsMaster.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+            TempSensorEntity(
+                client, self, "bmsMaster.minCellTemp", const.MIN_CELL_TEMP, False
+            ),
+            TempSensorEntity(
+                client, self, "bmsMaster.maxCellTemp", const.MAX_CELL_TEMP, False
+            ),
+            MilliampSensorEntity(
+                client, self, "bmsMaster.amp", const.BATTERY_AMP, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bmsMaster.vol", const.BATTERY_VOLT, False
+            )
+            .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
+            .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
+            MilliVoltSensorEntity(
+                client, self, "bmsMaster.minCellVol", const.MIN_CELL_VOLT, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bmsMaster.maxCellVol", const.MAX_CELL_VOLT, False
+            ),
             TempSensorEntity(client, self, "inv.inTemp", const.INV_IN_TEMP),
             TempSensorEntity(client, self, "inv.outTemp", const.INV_OUT_TEMP),
-
             # https://github.com/tolwi/hassio-ecoflow-cloud/discussions/87
             InEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
             InEnergySensorEntity(client, self, "pd.chgPowerAC", const.CHARGE_AC_ENERGY),
             InEnergySensorEntity(client, self, "pd.chgPowerDC", const.CHARGE_DC_ENERGY),
-            OutEnergySensorEntity(client, self, "pd.dsgPowerAC", const.DISCHARGE_AC_ENERGY),
-            OutEnergySensorEntity(client, self, "pd.dsgPowerDC", const.DISCHARGE_DC_ENERGY),
-
+            OutEnergySensorEntity(
+                client, self, "pd.dsgPowerAC", const.DISCHARGE_AC_ENERGY
+            ),
+            OutEnergySensorEntity(
+                client, self, "pd.dsgPowerDC", const.DISCHARGE_DC_ENERGY
+            ),
             # Optional Slave Batteries
-            LevelSensorEntity(client, self, "bmsSlave1.soc", const.SLAVE_BATTERY_LEVEL, False, True)
-                .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bmsSlave1.designCap", const.SLAVE_DESIGN_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bmsSlave1.fullCap", const.SLAVE_FULL_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bmsSlave1.remainCap", const.SLAVE_REMAIN_CAPACITY, False),
-
-            TempSensorEntity(client, self, "bmsSlave1.temp", const.SLAVE_BATTERY_TEMP, False, True)
-                .attr("bmsSlave1.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-                .attr("bmsSlave1.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            TempSensorEntity(client, self, "bmsSlave1.minCellTemp", const.SLAVE_MIN_CELL_TEMP, False),
-            TempSensorEntity(client, self, "bmsSlave1.maxCellTemp", const.SLAVE_MAX_CELL_TEMP, False),
-
-            MilliampSensorEntity(client, self, "bmsSlave1.amp", const.SLAVE_BATTERY_AMP, False),
-            MilliVoltSensorEntity(client, self, "bmsSlave1.vol", const.SLAVE_BATTERY_VOLT, False)
-                .attr("bmsSlave1.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
-                .attr("bmsSlave1.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            MilliVoltSensorEntity(client, self, "bmsSlave1.minCellVol", const.SLAVE_MIN_CELL_VOLT, False),
-            MilliVoltSensorEntity(client, self, "bmsSlave1.maxCellVol", const.SLAVE_MAX_CELL_VOLT, False),
-
-            CyclesSensorEntity(client, self, "bmsSlave1.cycles", const.SLAVE_CYCLES, False, True),
-            QuotaStatusSensorEntity(client, self)
+            LevelSensorEntity(
+                client, self, "bmsSlave1.soc", const.SLAVE_BATTERY_LEVEL, False, True
+            )
+            .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            CapacitySensorEntity(
+                client, self, "bmsSlave1.designCap", const.SLAVE_DESIGN_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bmsSlave1.fullCap", const.SLAVE_FULL_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bmsSlave1.remainCap", const.SLAVE_REMAIN_CAPACITY, False
+            ),
+            TempSensorEntity(
+                client, self, "bmsSlave1.temp", const.SLAVE_BATTERY_TEMP, False, True
+            )
+            .attr("bmsSlave1.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+            .attr("bmsSlave1.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+            TempSensorEntity(
+                client, self, "bmsSlave1.minCellTemp", const.SLAVE_MIN_CELL_TEMP, False
+            ),
+            TempSensorEntity(
+                client, self, "bmsSlave1.maxCellTemp", const.SLAVE_MAX_CELL_TEMP, False
+            ),
+            MilliampSensorEntity(
+                client, self, "bmsSlave1.amp", const.SLAVE_BATTERY_AMP, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bmsSlave1.vol", const.SLAVE_BATTERY_VOLT, False
+            )
+            .attr("bmsSlave1.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
+            .attr("bmsSlave1.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
+            MilliVoltSensorEntity(
+                client, self, "bmsSlave1.minCellVol", const.SLAVE_MIN_CELL_VOLT, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bmsSlave1.maxCellVol", const.SLAVE_MAX_CELL_VOLT, False
+            ),
+            CyclesSensorEntity(
+                client, self, "bmsSlave1.cycles", const.SLAVE_CYCLES, False, True
+            ),
+            QuotaStatusSensorEntity(client, self),
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return [
-            MaxBatteryLevelEntity(client, self, "bmsMaster.maxChargeSoc", const.MAX_CHARGE_LEVEL, 30, 100, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 49, "maxChgSoc": value}}),
+            MaxBatteryLevelEntity(
+                client,
+                self,
+                "bmsMaster.maxChargeSoc",
+                const.MAX_CHARGE_LEVEL,
+                30,
+                100,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 49, "maxChgSoc": value},
+                },
+            ),
         ]
 
     def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
         return [
-            BeeperEntity(client, self, "pd.beepState", const.BEEPER, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 38, "enabled": value}}),
-            EnabledEntity(client, self, "inv.cfgAcEnabled", const.AC_ENABLED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 66, "enabled": value}}),
-            EnabledEntity(client, self, "pd.carSwitch", const.DC_ENABLED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 34, "enabled": value}}),
-            EnabledEntity(client, self, "inv.cfgAcXboost", const.XBOOST_ENABLED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 66, "xboost": value}}),
-            FanModeEntity(client, self, "inv.cfgFanMode", const.AUTO_FAN_SPEED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 73, "fanMode": value}})
+            BeeperEntity(
+                client,
+                self,
+                "pd.beepState",
+                const.BEEPER,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 38, "enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "inv.cfgAcEnabled",
+                const.AC_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 66, "enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.carSwitch",
+                const.DC_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 34, "enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "inv.cfgAcXboost",
+                const.XBOOST_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 66, "xboost": value},
+                },
+            ),
+            FanModeEntity(
+                client,
+                self,
+                "inv.cfgFanMode",
+                const.AUTO_FAN_SPEED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 73, "fanMode": value},
+                },
+            ),
         ]
-    
+
     def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:
         return [
-
-            TimeoutDictSelectEntity(client, self, "pd.standByMode", const.UNIT_TIMEOUT, const.UNIT_TIMEOUT_OPTIONS_LIMITED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 33, "standByMode": value}}),
-            TimeoutDictSelectEntity(client, self, "pd.carDelayOffMin", const.DC_TIMEOUT, const.DC_TIMEOUT_OPTIONS_LIMITED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"cmdSet": 32, "id": 84, "carDelayOffMin": value}}),
-            TimeoutDictSelectEntity(client, self, "inv.cfgStandbyMin", const.AC_TIMEOUT, const.AC_TIMEOUT_OPTIONS_LIMITED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 153, "standByMins": value}}),
-
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "pd.standByMode",
+                const.UNIT_TIMEOUT,
+                const.UNIT_TIMEOUT_OPTIONS_LIMITED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 33, "standByMode": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "pd.carDelayOffMin",
+                const.DC_TIMEOUT,
+                const.DC_TIMEOUT_OPTIONS_LIMITED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"cmdSet": 32, "id": 84, "carDelayOffMin": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "inv.cfgStandbyMin",
+                const.AC_TIMEOUT,
+                const.AC_TIMEOUT_OPTIONS_LIMITED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 153, "standByMins": value},
+                },
+            ),
         ]
-

--- a/custom_components/ecoflow_cloud/devices/internal/river_mini.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river_mini.py
@@ -1,56 +1,99 @@
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import const, BaseDevice
-from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, BaseSelectEntity
+from custom_components.ecoflow_cloud.entities import (
+    BaseSensorEntity,
+    BaseNumberEntity,
+    BaseSwitchEntity,
+    BaseSelectEntity,
+)
 from custom_components.ecoflow_cloud.number import MaxBatteryLevelEntity
-from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSensorEntity, TempSensorEntity, \
-    CyclesSensorEntity, InEnergySensorEntity, InWattsSensorEntity, OutEnergySensorEntity, OutWattsSensorEntity, \
-    MilliampSensorEntity, InMilliVoltSensorEntity, \
-    BeMilliVoltSensorEntity
+from custom_components.ecoflow_cloud.sensor import (
+    LevelSensorEntity,
+    WattsSensorEntity,
+    TempSensorEntity,
+    CyclesSensorEntity,
+    InEnergySensorEntity,
+    InWattsSensorEntity,
+    OutEnergySensorEntity,
+    OutWattsSensorEntity,
+    MilliampSensorEntity,
+    InMilliVoltSensorEntity,
+    BeMilliVoltSensorEntity,
+)
 from custom_components.ecoflow_cloud.switch import EnabledEntity
 
 
 class RiverMini(BaseDevice):
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
-            LevelSensorEntity(client, self, "inv.soc", const.MAIN_BATTERY_LEVEL)
-                    .attr("inv.maxChargeSoc", const.ATTR_DESIGN_CAPACITY, 0),
-
+            LevelSensorEntity(client, self, "inv.soc", const.MAIN_BATTERY_LEVEL).attr(
+                "inv.maxChargeSoc", const.ATTR_DESIGN_CAPACITY, 0
+            ),
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
-
             BeMilliVoltSensorEntity(client, self, "inv.invInVol", const.AC_IN_VOLT),
             BeMilliVoltSensorEntity(client, self, "inv.invOutVol", const.AC_OUT_VOLT),
-
-            InMilliVoltSensorEntity(client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
+            InMilliVoltSensorEntity(
+                client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE
+            ),
             MilliampSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
-
             TempSensorEntity(client, self, "inv.inTemp", const.INV_IN_TEMP),
             TempSensorEntity(client, self, "inv.outTemp", const.INV_OUT_TEMP),
-
             InEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
             InEnergySensorEntity(client, self, "pd.chgPowerAC", const.CHARGE_AC_ENERGY),
             InEnergySensorEntity(client, self, "pd.chgPowerDC", const.CHARGE_DC_ENERGY),
-            OutEnergySensorEntity(client, self, "pd.dsgPowerAC", const.DISCHARGE_AC_ENERGY),
-            OutEnergySensorEntity(client, self, "pd.dsgPowerDC", const.DISCHARGE_DC_ENERGY),
-
+            OutEnergySensorEntity(
+                client, self, "pd.dsgPowerAC", const.DISCHARGE_AC_ENERGY
+            ),
+            OutEnergySensorEntity(
+                client, self, "pd.dsgPowerDC", const.DISCHARGE_DC_ENERGY
+            ),
             WattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             WattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
-
-
             CyclesSensorEntity(client, self, "inv.cycles", const.CYCLES),
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return [
-            MaxBatteryLevelEntity(client, self, "inv.maxChargeSoc", const.MAX_CHARGE_LEVEL, 30, 100,
-                                  lambda value: {"moduleType": 0, "operateType": "TCP",
-                                                 "params": {"id": 0, "maxChgSoc": value}}),
+            MaxBatteryLevelEntity(
+                client,
+                self,
+                "inv.maxChargeSoc",
+                const.MAX_CHARGE_LEVEL,
+                30,
+                100,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 0, "maxChgSoc": value},
+                },
+            ),
         ]
 
     def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
         return [
-            EnabledEntity(client, self, "inv.cfgAcEnabled", const.AC_ENABLED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 66, "enabled": value}}),
-            EnabledEntity(client, self, "inv.cfgAcXboost", const.XBOOST_ENABLED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 66, "xboost": value}}),
+            EnabledEntity(
+                client,
+                self,
+                "inv.cfgAcEnabled",
+                const.AC_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 66, "enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "inv.cfgAcXboost",
+                const.XBOOST_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 66, "xboost": value},
+                },
+            ),
         ]
 
     def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:

--- a/custom_components/ecoflow_cloud/devices/internal/river_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river_pro.py
@@ -1,13 +1,31 @@
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import const, BaseDevice
-from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, BaseSelectEntity
+from custom_components.ecoflow_cloud.entities import (
+    BaseSensorEntity,
+    BaseNumberEntity,
+    BaseSwitchEntity,
+    BaseSelectEntity,
+)
 from custom_components.ecoflow_cloud.number import MaxBatteryLevelEntity
 from custom_components.ecoflow_cloud.select import TimeoutDictSelectEntity
-from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, WattsSensorEntity, RemainSensorEntity, \
-    TempSensorEntity, \
-    CyclesSensorEntity, InEnergySensorEntity, InWattsSensorEntity, OutEnergySensorEntity, OutWattsSensorEntity, \
-    InMilliampSensorEntity, MilliampSensorEntity, MilliVoltSensorEntity, InMilliVoltSensorEntity, \
-    OutMilliVoltSensorEntity, CapacitySensorEntity, QuotaStatusSensorEntity
+from custom_components.ecoflow_cloud.sensor import (
+    LevelSensorEntity,
+    WattsSensorEntity,
+    RemainSensorEntity,
+    TempSensorEntity,
+    CyclesSensorEntity,
+    InEnergySensorEntity,
+    InWattsSensorEntity,
+    OutEnergySensorEntity,
+    OutWattsSensorEntity,
+    InMilliampSensorEntity,
+    MilliampSensorEntity,
+    MilliVoltSensorEntity,
+    InMilliVoltSensorEntity,
+    OutMilliVoltSensorEntity,
+    CapacitySensorEntity,
+    QuotaStatusSensorEntity,
+)
 from custom_components.ecoflow_cloud.switch import EnabledEntity, BeeperEntity
 
 
@@ -15,115 +33,257 @@ class RiverPro(BaseDevice):
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
             LevelSensorEntity(client, self, "bmsMaster.soc", const.MAIN_BATTERY_LEVEL)
-                .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            .attr("bmsMaster.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsMaster.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsMaster.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
             # Not available on River Pro units
             # CapacitySensorEntity(client, self, "bmsMaster.designCap", const.MAIN_DESIGN_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bmsMaster.fullCap", const.MAIN_FULL_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bmsMaster.remainCap", const.MAIN_REMAIN_CAPACITY, False),
-
+            CapacitySensorEntity(
+                client, self, "bmsMaster.fullCap", const.MAIN_FULL_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bmsMaster.remainCap", const.MAIN_REMAIN_CAPACITY, False
+            ),
             LevelSensorEntity(client, self, "pd.soc", const.COMBINED_BATTERY_LEVEL),
             WattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             WattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
-
             InMilliampSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
-            InMilliVoltSensorEntity(client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE),
-
+            InMilliVoltSensorEntity(
+                client, self, "inv.dcInVol", const.SOLAR_IN_VOLTAGE
+            ),
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
-
             InMilliVoltSensorEntity(client, self, "inv.invInVol", const.AC_IN_VOLT),
             OutMilliVoltSensorEntity(client, self, "inv.invOutVol", const.AC_OUT_VOLT),
-
             OutWattsSensorEntity(client, self, "pd.carWatts", const.DC_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.typecWatts", const.TYPEC_OUT_POWER),
             # disabled by default because they aren't terribly useful
             TempSensorEntity(client, self, "pd.carTemp", const.DC_CAR_OUT_TEMP, False),
             TempSensorEntity(client, self, "pd.typecTemp", const.USB_C_TEMP, False),
-
             OutWattsSensorEntity(client, self, "pd.usb1Watts", const.USB_1_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb2Watts", const.USB_2_OUT_POWER),
             OutWattsSensorEntity(client, self, "pd.usb3Watts", const.USB_3_OUT_POWER),
-
             RemainSensorEntity(client, self, "pd.remainTime", const.REMAINING_TIME),
             CyclesSensorEntity(client, self, "bmsMaster.cycles", const.CYCLES),
-
             TempSensorEntity(client, self, "bmsMaster.temp", const.BATTERY_TEMP)
-                .attr("bmsMaster.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-                .attr("bmsMaster.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            TempSensorEntity(client, self, "bmsMaster.minCellTemp", const.MIN_CELL_TEMP, False),
-            TempSensorEntity(client, self, "bmsMaster.maxCellTemp", const.MAX_CELL_TEMP, False),
-
-            MilliampSensorEntity(client, self, "bmsMaster.amp", const.BATTERY_AMP, False),
-            MilliVoltSensorEntity(client, self, "bmsMaster.vol", const.BATTERY_VOLT, False)
-                .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
-                .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            MilliVoltSensorEntity(client, self, "bmsMaster.minCellVol", const.MIN_CELL_VOLT, False),
-            MilliVoltSensorEntity(client, self, "bmsMaster.maxCellVol", const.MAX_CELL_VOLT, False),
-
+            .attr("bmsMaster.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+            .attr("bmsMaster.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+            TempSensorEntity(
+                client, self, "bmsMaster.minCellTemp", const.MIN_CELL_TEMP, False
+            ),
+            TempSensorEntity(
+                client, self, "bmsMaster.maxCellTemp", const.MAX_CELL_TEMP, False
+            ),
+            MilliampSensorEntity(
+                client, self, "bmsMaster.amp", const.BATTERY_AMP, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bmsMaster.vol", const.BATTERY_VOLT, False
+            )
+            .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
+            .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
+            MilliVoltSensorEntity(
+                client, self, "bmsMaster.minCellVol", const.MIN_CELL_VOLT, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bmsMaster.maxCellVol", const.MAX_CELL_VOLT, False
+            ),
             TempSensorEntity(client, self, "inv.inTemp", const.INV_IN_TEMP),
             TempSensorEntity(client, self, "inv.outTemp", const.INV_OUT_TEMP),
-
             # https://github.com/tolwi/hassio-ecoflow-cloud/discussions/87
             InEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
             InEnergySensorEntity(client, self, "pd.chgPowerAC", const.CHARGE_AC_ENERGY),
             InEnergySensorEntity(client, self, "pd.chgPowerDC", const.CHARGE_DC_ENERGY),
-            OutEnergySensorEntity(client, self, "pd.dsgPowerAC", const.DISCHARGE_AC_ENERGY),
-            OutEnergySensorEntity(client, self, "pd.dsgPowerDC", const.DISCHARGE_DC_ENERGY),
-
+            OutEnergySensorEntity(
+                client, self, "pd.dsgPowerAC", const.DISCHARGE_AC_ENERGY
+            ),
+            OutEnergySensorEntity(
+                client, self, "pd.dsgPowerDC", const.DISCHARGE_DC_ENERGY
+            ),
             # Optional Slave Batteries
-            LevelSensorEntity(client, self, "bmsSlave1.soc", const.SLAVE_BATTERY_LEVEL, False, True)
-                .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
-                .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
-                .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
+            LevelSensorEntity(
+                client, self, "bmsSlave1.soc", const.SLAVE_BATTERY_LEVEL, False, True
+            )
+            .attr("bmsSlave1.designCap", const.ATTR_DESIGN_CAPACITY, 0)
+            .attr("bmsSlave1.fullCap", const.ATTR_FULL_CAPACITY, 0)
+            .attr("bmsSlave1.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
             # Not available on River Pro units
             # CapacitySensorEntity(client, self, "bmsSlave1.designCap", const.SLAVE_DESIGN_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bmsSlave1.fullCap", const.SLAVE_FULL_CAPACITY, False),
-            CapacitySensorEntity(client, self, "bmsSlave1.remainCap", const.SLAVE_REMAIN_CAPACITY, False),
-
-            CyclesSensorEntity(client, self, "bmsSlave1.cycles", const.SLAVE_CYCLES, False, True),
-            TempSensorEntity(client, self, "bmsSlave1.temp", const.SLAVE_BATTERY_TEMP, False, True)
-                .attr("bmsSlave1.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
-                .attr("bmsSlave1.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            TempSensorEntity(client, self, "bmsSlave1.minCellTemp", const.SLAVE_MIN_CELL_TEMP, False),
-            TempSensorEntity(client, self, "bmsSlave1.maxCellTemp", const.SLAVE_MAX_CELL_TEMP, False),
-
-            MilliampSensorEntity(client, self, "bmsSlave1.amp", const.SLAVE_BATTERY_AMP, False),
-            MilliVoltSensorEntity(client, self, "bmsSlave1.vol", const.SLAVE_BATTERY_VOLT, False)
-                .attr("bmsSlave1.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
-                .attr("bmsSlave1.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            MilliVoltSensorEntity(client, self, "bmsSlave1.minCellVol", const.SLAVE_MIN_CELL_VOLT, False),
-            MilliVoltSensorEntity(client, self, "bmsSlave1.maxCellVol", const.SLAVE_MAX_CELL_VOLT, False),
-            QuotaStatusSensorEntity(client, self)
+            CapacitySensorEntity(
+                client, self, "bmsSlave1.fullCap", const.SLAVE_FULL_CAPACITY, False
+            ),
+            CapacitySensorEntity(
+                client, self, "bmsSlave1.remainCap", const.SLAVE_REMAIN_CAPACITY, False
+            ),
+            CyclesSensorEntity(
+                client, self, "bmsSlave1.cycles", const.SLAVE_CYCLES, False, True
+            ),
+            TempSensorEntity(
+                client, self, "bmsSlave1.temp", const.SLAVE_BATTERY_TEMP, False, True
+            )
+            .attr("bmsSlave1.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
+            .attr("bmsSlave1.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
+            TempSensorEntity(
+                client, self, "bmsSlave1.minCellTemp", const.SLAVE_MIN_CELL_TEMP, False
+            ),
+            TempSensorEntity(
+                client, self, "bmsSlave1.maxCellTemp", const.SLAVE_MAX_CELL_TEMP, False
+            ),
+            MilliampSensorEntity(
+                client, self, "bmsSlave1.amp", const.SLAVE_BATTERY_AMP, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bmsSlave1.vol", const.SLAVE_BATTERY_VOLT, False
+            )
+            .attr("bmsSlave1.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
+            .attr("bmsSlave1.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
+            MilliVoltSensorEntity(
+                client, self, "bmsSlave1.minCellVol", const.SLAVE_MIN_CELL_VOLT, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "bmsSlave1.maxCellVol", const.SLAVE_MAX_CELL_VOLT, False
+            ),
+            QuotaStatusSensorEntity(client, self),
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return [
-            MaxBatteryLevelEntity(client, self, "bmsMaster.maxChargeSoc", const.MAX_CHARGE_LEVEL, 30, 100, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 49, "maxChgSoc": value}}),
+            MaxBatteryLevelEntity(
+                client,
+                self,
+                "bmsMaster.maxChargeSoc",
+                const.MAX_CHARGE_LEVEL,
+                30,
+                100,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 49, "maxChgSoc": value},
+                },
+            ),
         ]
 
     def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
         return [
-            BeeperEntity(client, self, "pd.beepState", const.BEEPER, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 38, "enabled": value}}),
-            EnabledEntity(client, self, "inv.acAutoOutConfig", const.AC_ALWAYS_ENABLED,
-                          lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 95, "acautooutConfig": value, "minAcoutSoc": 255}}),
-            EnabledEntity(client, self, "pd.carSwitch", const.DC_ENABLED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 34, "enabled": value}}),
-            EnabledEntity(client, self, "inv.cfgAcEnabled", const.AC_ENABLED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 66, "enabled": value}}),
-            EnabledEntity(client, self, "inv.cfgAcXboost", const.XBOOST_ENABLED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 66, "xboost": value}}),
-            EnabledEntity(client, self, "inv.cfgAcChgModeFlg", const.AC_SLOW_CHARGE, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 65, "workMode": value}}),
-            EnabledEntity(client, self, "inv.cfgFanMode", const.AUTO_FAN_SPEED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 73, "fanMode": value}})
+            BeeperEntity(
+                client,
+                self,
+                "pd.beepState",
+                const.BEEPER,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 38, "enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "inv.acAutoOutConfig",
+                const.AC_ALWAYS_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 95, "acautooutConfig": value, "minAcoutSoc": 255},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "pd.carSwitch",
+                const.DC_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 34, "enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "inv.cfgAcEnabled",
+                const.AC_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 66, "enabled": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "inv.cfgAcXboost",
+                const.XBOOST_ENABLED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 66, "xboost": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "inv.cfgAcChgModeFlg",
+                const.AC_SLOW_CHARGE,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 65, "workMode": value},
+                },
+            ),
+            EnabledEntity(
+                client,
+                self,
+                "inv.cfgFanMode",
+                const.AUTO_FAN_SPEED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 73, "fanMode": value},
+                },
+            ),
         ]
 
     def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:
         return [
-            TimeoutDictSelectEntity(client, self, "pd.standByMode", const.UNIT_TIMEOUT, const.UNIT_TIMEOUT_OPTIONS_LIMITED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 33, "standByMode": value}}),
-            TimeoutDictSelectEntity(client, self, "pd.carDelayOffMin", const.DC_TIMEOUT, const.DC_TIMEOUT_OPTIONS_LIMITED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"cmdSet": 32, "id": 84, "carDelayOffMin": value}}),
-            TimeoutDictSelectEntity(client, self, "inv.cfgStandbyMin", const.AC_TIMEOUT, const.AC_TIMEOUT_OPTIONS_LIMITED, lambda value: {"moduleType": 0, "operateType": "TCP", "params": {"id": 153, "standByMins": value}})
-
-			# lambda is confirmed correct, but pd.lcdOffSec is missing from status
-			# TimeoutDictSelectEntity(client, self, "pd.lcdOffSec", const.SCREEN_TIMEOUT, const.SCREEN_TIMEOUT_OPTIONS,
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "pd.standByMode",
+                const.UNIT_TIMEOUT,
+                const.UNIT_TIMEOUT_OPTIONS_LIMITED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 33, "standByMode": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "pd.carDelayOffMin",
+                const.DC_TIMEOUT,
+                const.DC_TIMEOUT_OPTIONS_LIMITED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"cmdSet": 32, "id": 84, "carDelayOffMin": value},
+                },
+            ),
+            TimeoutDictSelectEntity(
+                client,
+                self,
+                "inv.cfgStandbyMin",
+                const.AC_TIMEOUT,
+                const.AC_TIMEOUT_OPTIONS_LIMITED,
+                lambda value: {
+                    "moduleType": 0,
+                    "operateType": "TCP",
+                    "params": {"id": 153, "standByMins": value},
+                },
+            ),
+            # lambda is confirmed correct, but pd.lcdOffSec is missing from status
+            # TimeoutDictSelectEntity(client, self, "pd.lcdOffSec", const.SCREEN_TIMEOUT, const.SCREEN_TIMEOUT_OPTIONS,
             #                        lambda value: {"moduleType": 0, "operateType": "TCP",
             #                                       "params": {"lcdTime": value, "id": 39}})
         ]
-

--- a/custom_components/ecoflow_cloud/devices/internal/smart_meter.py
+++ b/custom_components/ecoflow_cloud/devices/internal/smart_meter.py
@@ -1,42 +1,108 @@
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import const, BaseDevice
-from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, \
-    BaseSelectEntity
-from custom_components.ecoflow_cloud.sensor import WattsSensorEntity, InAmpSensorEntity, MilliVoltSensorEntity, \
-    EnergySensorEntity, MiscBinarySensorEntity
+from custom_components.ecoflow_cloud.entities import (
+    BaseSensorEntity,
+    BaseNumberEntity,
+    BaseSwitchEntity,
+    BaseSelectEntity,
+)
+from custom_components.ecoflow_cloud.sensor import (
+    WattsSensorEntity,
+    InAmpSensorEntity,
+    MilliVoltSensorEntity,
+    EnergySensorEntity,
+    MiscBinarySensorEntity,
+)
+
 
 class SmartMeter(BaseDevice):
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
-            WattsSensorEntity(client, self, "powGetSysGrid", const.SMART_METER_POWER_GLOBAL),
-
-            WattsSensorEntity(client, self, "gridConnectionPowerL1", const.SMART_METER_POWER_L1, False),
-            WattsSensorEntity(client, self, "gridConnectionPowerL2", const.SMART_METER_POWER_L2, False),
-            WattsSensorEntity(client, self, "gridConnectionPowerL3", const.SMART_METER_POWER_L3, False),
-
-            InAmpSensorEntity(client, self, "gridConnectionAmpL1", const.SMART_METER_IN_AMPS_L1, False),
-            InAmpSensorEntity(client, self, "gridConnectionAmpL2", const.SMART_METER_IN_AMPS_L2, False),
-            InAmpSensorEntity(client, self, "gridConnectionAmpL3", const.SMART_METER_IN_AMPS_L3, False),
-
-            MilliVoltSensorEntity(client, self, "gridConnectionVolL1", const.SMART_METER_VOLT_L1, False),
-            MilliVoltSensorEntity(client, self, "gridConnectionVolL2", const.SMART_METER_VOLT_L2, False),
-            MilliVoltSensorEntity(client, self, "gridConnectionVolL3", const.SMART_METER_VOLT_L3, False),
-
-            MiscBinarySensorEntity(client, self, "gridConnectionFlagL1", const.SMART_METER_FLAG_L1, False),
-            MiscBinarySensorEntity(client, self, "gridConnectionFlagL2", const.SMART_METER_FLAG_L2, False),
-            MiscBinarySensorEntity(client, self, "gridConnectionFlagL3", const.SMART_METER_FLAG_L3, False),
-
-            EnergySensorEntity(client, self, "gridConnectionDataRecord.todayActiveL1", const.SMART_METER_RECORD_ACTIVE_TODAY_L1,False),
-            EnergySensorEntity(client, self, "gridConnectionDataRecord.todayActiveL2", const.SMART_METER_RECORD_ACTIVE_TODAY_L2, False),
-            EnergySensorEntity(client, self, "gridConnectionDataRecord.todayActiveL3", const.SMART_METER_RECORD_ACTIVE_TODAY_L3, False),
-
-            EnergySensorEntity(client, self, "gridConnectionDataRecord.todayActive", const.SMART_METER_RECORD_ACTIVE_TODAY),
-            EnergySensorEntity(client, self, "gridConnectionDataRecord.todayReactive", const.SMART_METER_RECORD_REACTIVE_TODAY, False),
-            EnergySensorEntity(client, self, "gridConnectionDataRecord.totalActiveEnergy", const.SMART_METER_RECORD_ACTIVE_TOTAL),
-            EnergySensorEntity(client, self, "gridConnectionDataRecord.totalReactiveEnergy", const.SMART_METER_RECORD_REACTIVE_TOTAL),
-
-
-
+            WattsSensorEntity(
+                client, self, "powGetSysGrid", const.SMART_METER_POWER_GLOBAL
+            ),
+            WattsSensorEntity(
+                client, self, "gridConnectionPowerL1", const.SMART_METER_POWER_L1, False
+            ),
+            WattsSensorEntity(
+                client, self, "gridConnectionPowerL2", const.SMART_METER_POWER_L2, False
+            ),
+            WattsSensorEntity(
+                client, self, "gridConnectionPowerL3", const.SMART_METER_POWER_L3, False
+            ),
+            InAmpSensorEntity(
+                client, self, "gridConnectionAmpL1", const.SMART_METER_IN_AMPS_L1, False
+            ),
+            InAmpSensorEntity(
+                client, self, "gridConnectionAmpL2", const.SMART_METER_IN_AMPS_L2, False
+            ),
+            InAmpSensorEntity(
+                client, self, "gridConnectionAmpL3", const.SMART_METER_IN_AMPS_L3, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "gridConnectionVolL1", const.SMART_METER_VOLT_L1, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "gridConnectionVolL2", const.SMART_METER_VOLT_L2, False
+            ),
+            MilliVoltSensorEntity(
+                client, self, "gridConnectionVolL3", const.SMART_METER_VOLT_L3, False
+            ),
+            MiscBinarySensorEntity(
+                client, self, "gridConnectionFlagL1", const.SMART_METER_FLAG_L1, False
+            ),
+            MiscBinarySensorEntity(
+                client, self, "gridConnectionFlagL2", const.SMART_METER_FLAG_L2, False
+            ),
+            MiscBinarySensorEntity(
+                client, self, "gridConnectionFlagL3", const.SMART_METER_FLAG_L3, False
+            ),
+            EnergySensorEntity(
+                client,
+                self,
+                "gridConnectionDataRecord.todayActiveL1",
+                const.SMART_METER_RECORD_ACTIVE_TODAY_L1,
+                False,
+            ),
+            EnergySensorEntity(
+                client,
+                self,
+                "gridConnectionDataRecord.todayActiveL2",
+                const.SMART_METER_RECORD_ACTIVE_TODAY_L2,
+                False,
+            ),
+            EnergySensorEntity(
+                client,
+                self,
+                "gridConnectionDataRecord.todayActiveL3",
+                const.SMART_METER_RECORD_ACTIVE_TODAY_L3,
+                False,
+            ),
+            EnergySensorEntity(
+                client,
+                self,
+                "gridConnectionDataRecord.todayActive",
+                const.SMART_METER_RECORD_ACTIVE_TODAY,
+            ),
+            EnergySensorEntity(
+                client,
+                self,
+                "gridConnectionDataRecord.todayReactive",
+                const.SMART_METER_RECORD_REACTIVE_TODAY,
+                False,
+            ),
+            EnergySensorEntity(
+                client,
+                self,
+                "gridConnectionDataRecord.totalActiveEnergy",
+                const.SMART_METER_RECORD_ACTIVE_TOTAL,
+            ),
+            EnergySensorEntity(
+                client,
+                self,
+                "gridConnectionDataRecord.totalReactiveEnergy",
+                const.SMART_METER_RECORD_REACTIVE_TOTAL,
+            ),
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:

--- a/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
@@ -1,26 +1,49 @@
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import const, BaseDevice
-from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, \
-    BaseSelectEntity
-from custom_components.ecoflow_cloud.sensor import WattsSensorEntity,LevelSensorEntity,CapacitySensorEntity, \
-    InWattsSensorEntity,OutWattsSensorEntity, RemainSensorEntity, MilliVoltSensorEntity, TempSensorEntity, \
-    CyclesSensorEntity, EnergySensorEntity, CumulativeCapacitySensorEntity
+from custom_components.ecoflow_cloud.entities import (
+    BaseSensorEntity,
+    BaseNumberEntity,
+    BaseSwitchEntity,
+    BaseSelectEntity,
+)
+from custom_components.ecoflow_cloud.sensor import (
+    WattsSensorEntity,
+    LevelSensorEntity,
+    CapacitySensorEntity,
+    InWattsSensorEntity,
+    OutWattsSensorEntity,
+    RemainSensorEntity,
+    MilliVoltSensorEntity,
+    TempSensorEntity,
+    CyclesSensorEntity,
+    EnergySensorEntity,
+    CumulativeCapacitySensorEntity,
+)
 from homeassistant.util import utcnow
 import logging
 
 _LOGGER = logging.getLogger(__name__)
 
+
 class StreamAC(BaseDevice):
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
             # "accuChgCap": 198511,
-            CumulativeCapacitySensorEntity(client, self, "accuChgCap", const.ACCU_CHARGE_CAP, False),
+            CumulativeCapacitySensorEntity(
+                client, self, "accuChgCap", const.ACCU_CHARGE_CAP, False
+            ),
             # "accuChgEnergy": 3992,
-            EnergySensorEntity(client, self, "accuChgEnergy", const.ACCU_CHARGE_ENERGY, False),
+            EnergySensorEntity(
+                client, self, "accuChgEnergy", const.ACCU_CHARGE_ENERGY, False
+            ),
             # "accuDsgCap": 184094,
-            CumulativeCapacitySensorEntity(client, self, "accuDsgCap", const.ACCU_DISCHARGE_CAP, False),
+            CumulativeCapacitySensorEntity(
+                client, self, "accuDsgCap", const.ACCU_DISCHARGE_CAP, False
+            ),
             # "accuDsgEnergy": 3646,
-            EnergySensorEntity(client, self, "accuDsgEnergy", const.ACCU_DISCHARGE_ENERGY, False),
+            EnergySensorEntity(
+                client, self, "accuDsgEnergy", const.ACCU_DISCHARGE_ENERGY, False
+            ),
             # "actSoc": 46.0,
             # "amp": 44671,
             # "backupReverseSoc": 5,
@@ -33,10 +56,14 @@ class StreamAC(BaseDevice):
             # "bmsBattSoh": 100.0,
             # "bmsChgDsgState": 2,
             # "bmsChgRemTime": 88,
-            RemainSensorEntity(client, self, "bmsChgRemTime", const.CHARGE_REMAINING_TIME, False),
+            RemainSensorEntity(
+                client, self, "bmsChgRemTime", const.CHARGE_REMAINING_TIME, False
+            ),
             # "bmsDesignCap": 1920,
             # "bmsDsgRemTime": 5939,
-            RemainSensorEntity(client, self, "bmsDsgRemTime", const.DISCHARGE_REMAINING_TIME, False),
+            RemainSensorEntity(
+                client, self, "bmsDsgRemTime", const.DISCHARGE_REMAINING_TIME, False
+            ),
             # "bmsFault": 0,
             # "bmsFaultState": 0,
             # "bmsHeartbeatVer": 260,
@@ -76,9 +103,11 @@ class StreamAC(BaseDevice):
             # "curSensorTemp": [],
             # "cycleSoh": 100.0,
             # "cycles": 1,
-            CyclesSensorEntity(client, self, "cycles", const.CYCLES,False),
+            CyclesSensorEntity(client, self, "cycles", const.CYCLES, False),
             # "designCap": 100000,
-            CapacitySensorEntity(client, self, "designCap", const.STREAM_DESIGN_CAPACITY,False),
+            CapacitySensorEntity(
+                client, self, "designCap", const.STREAM_DESIGN_CAPACITY, False
+            ),
             # "devCtrlStatus": 1,
             # "devSleepState": 0,
             # "diffSoc": 0.2050476,
@@ -92,33 +121,45 @@ class StreamAC(BaseDevice):
             # "energyStrategyOperateMode.operateSelfPoweredOpen": true,
             # "energyStrategyOperateMode.operateTouModeOpen": false,
             # "f32ShowSoc": 46.317574,
-            LevelSensorEntity(client, self, "f32ShowSoc", const.STREAM_POWER_BATTERY_SOC,False),
+            LevelSensorEntity(
+                client, self, "f32ShowSoc", const.STREAM_POWER_BATTERY_SOC, False
+            ),
             # "feedGridMode": 2,
             # "feedGridModePowLimit": 800,
             # "feedGridModePowMax": 800,
             # "fullCap": 100000,
-            CapacitySensorEntity(client, self, "fullCap", const.STREAM_FULL_CAPACITY, False),
+            CapacitySensorEntity(
+                client, self, "fullCap", const.STREAM_FULL_CAPACITY, False
+            ),
             # "gridCodeSelection": "GRID_STD_CODE_UTE_MAINLAND",
             # "gridCodeVersion": 10001,
             # "gridConnectionFreq": 49.974655,
             # "gridConnectionPower": -967.2364,
-            WattsSensorEntity(client, self, "gridConnectionPower", const.STREAM_POWER_AC),
+            WattsSensorEntity(
+                client, self, "gridConnectionPower", const.STREAM_POWER_AC
+            ),
             # "gridConnectionSta": "PANEL_GRID_IN",
             # "gridConnectionVol": 235.34576,
-            MilliVoltSensorEntity(client, self, "gridConnectionVol", const.STREAM_POWER_VOL, False),
+            MilliVoltSensorEntity(
+                client, self, "gridConnectionVol", const.STREAM_POWER_VOL, False
+            ),
             # "gridSysDeviceCnt": 2,
             # "heatfilmNtcNum": 0,
             # "heatfilmTemp": [],
             # "hwVer": "V0.0.0",
             # "inputWatts": 900,
-            InWattsSensorEntity(client, self, "inputWatts", const.STREAM_IN_POWER, False),
+            InWattsSensorEntity(
+                client, self, "inputWatts", const.STREAM_IN_POWER, False
+            ),
             # "invNtcTemp3": 49,
             # "maxBpInput": 1050,
             # "maxBpOutput": 1200,
             # "maxCellTemp": 35,
             TempSensorEntity(client, self, "maxCellTemp", const.MAX_CELL_TEMP, False),
             # "maxCellVol": 3362,
-            MilliVoltSensorEntity(client, self, "maxCellVol", const.MAX_CELL_VOLT, False),
+            MilliVoltSensorEntity(
+                client, self, "maxCellVol", const.MAX_CELL_VOLT, False
+            ),
             # "maxCurSensorTemp": 0,
             # "maxEnvTemp": 0,
             # "maxHeatfilmTemp": 0,
@@ -131,7 +172,9 @@ class StreamAC(BaseDevice):
             # "minCellTemp": 33,
             TempSensorEntity(client, self, "minCellTemp", const.MIN_CELL_TEMP, False),
             # "minCellVol": 3357,
-            MilliVoltSensorEntity(client, self, "minCellVol", const.MIN_CELL_VOLT, False),
+            MilliVoltSensorEntity(
+                client, self, "minCellVol", const.MIN_CELL_VOLT, False
+            ),
             # "minCurSensorTemp": 0,
             # "minEnvTemp": 0,
             # "minHeatfilmTemp": 0,
@@ -142,7 +185,9 @@ class StreamAC(BaseDevice):
             # "num": 0,
             # "openBmsFlag": 1,
             # "outputWatts": 0,
-            OutWattsSensorEntity(client, self, "outputWatts", const.STREAM_OUT_POWER, False),
+            OutWattsSensorEntity(
+                client, self, "outputWatts", const.STREAM_OUT_POWER, False
+            ),
             # "packSn": "BKxxxxx",
             # "plugInInfoPv2Amp": 0.0,
             # "plugInInfoPv2Flag": false,
@@ -160,29 +205,50 @@ class StreamAC(BaseDevice):
             # "powGetBpCms": 1915.0862,
             WattsSensorEntity(client, self, "powGetBpCms", const.STREAM_POWER_BATTERY),
             # "powGetPv": 0.0,
-            WattsSensorEntity(client, self, "powGetPv", const.STREAM_POWER_PV_1, False, True),
+            WattsSensorEntity(
+                client, self, "powGetPv", const.STREAM_POWER_PV_1, False, True
+            ),
             # "powGetPv2": 0.0,
-            WattsSensorEntity(client, self, "powGetPv2", const.STREAM_POWER_PV_2, False, True),
+            WattsSensorEntity(
+                client, self, "powGetPv2", const.STREAM_POWER_PV_2, False, True
+            ),
             # "powGetPv3": 0.0,
-            WattsSensorEntity(client, self, "powGetPv3", const.STREAM_POWER_PV_3, False, True),
+            WattsSensorEntity(
+                client, self, "powGetPv3", const.STREAM_POWER_PV_3, False, True
+            ),
             # "powGetPv4": 0.0,
-            WattsSensorEntity(client, self, "powGetPv4", const.STREAM_POWER_PV_4, False, True),
+            WattsSensorEntity(
+                client, self, "powGetPv4", const.STREAM_POWER_PV_4, False, True
+            ),
             # "powGetPvSum": 2051.3975,
             WattsSensorEntity(client, self, "powGetPvSum", const.STREAM_POWER_PV_SUM),
             # "powGetSchuko1": 0.0,
-            WattsSensorEntity(client, self, "powGetSchuko1", const.STREAM_GET_SCHUKO1, False, True),
+            WattsSensorEntity(
+                client, self, "powGetSchuko1", const.STREAM_GET_SCHUKO1, False, True
+            ),
             # "powGetSchuko2": 18.654325,
-            WattsSensorEntity(client, self, "powGetSchuko2", const.STREAM_GET_SCHUKO2, False, True),
+            WattsSensorEntity(
+                client, self, "powGetSchuko2", const.STREAM_GET_SCHUKO2, False, True
+            ),
             # "powGetSysGrid": -135.0,
             WattsSensorEntity(client, self, "powGetSysGrid", const.STREAM_POWER_GRID),
             # "powGetSysLoad": 0.0,
             WattsSensorEntity(client, self, "powGetSysLoad", const.STREAM_GET_SYS_LOAD),
             # "powGetSysLoadFromBp": 0.0,
-            WattsSensorEntity(client, self, "powGetSysLoadFromBp", const.STREAM_GET_SYS_LOAD_FROM_BP),
+            WattsSensorEntity(
+                client, self, "powGetSysLoadFromBp", const.STREAM_GET_SYS_LOAD_FROM_BP
+            ),
             # "powGetSysLoadFromGrid": 0.0,
-            WattsSensorEntity(client, self, "powGetSysLoadFromGrid", const.STREAM_GET_SYS_LOAD_FROM_GRID),
+            WattsSensorEntity(
+                client,
+                self,
+                "powGetSysLoadFromGrid",
+                const.STREAM_GET_SYS_LOAD_FROM_GRID,
+            ),
             # "powGetSysLoadFromPv": 0.0,
-            WattsSensorEntity(client, self, "powGetSysLoadFromPv", const.STREAM_GET_SYS_LOAD_FROM_PV),
+            WattsSensorEntity(
+                client, self, "powGetSysLoadFromPv", const.STREAM_GET_SYS_LOAD_FROM_PV
+            ),
             # "powSysAcInMax": 4462,
             # "powSysAcOutMax": 800,
             # "productDetail": 5,
@@ -194,7 +260,9 @@ class StreamAC(BaseDevice):
             # "relay3Onoff": true,
             # "relay4Onoff": true,
             # "remainCap": 46317,
-            CapacitySensorEntity(client, self, "remainCap", const.STREAM_REMAIN_CAPACITY,False),
+            CapacitySensorEntity(
+                client, self, "remainCap", const.STREAM_REMAIN_CAPACITY, False
+            ),
             # "remainTime": 88,
             RemainSensorEntity(client, self, "remainTime", const.REMAINING_TIME, False),
             # "runtimePropertyFullUploadPeriod": 120000,
@@ -213,7 +281,9 @@ class StreamAC(BaseDevice):
             # "stormPatternEndTime": 0,
             # "stormPatternOpenFlag": false,
             # "sysGridConnectionPower": -2020.0437,
-            WattsSensorEntity(client, self, "sysGridConnectionPower", const.STREAM_POWER_AC_SYS, False),
+            WattsSensorEntity(
+                client, self, "sysGridConnectionPower", const.STREAM_POWER_AC_SYS, False
+            ),
             # "sysLoaderVer": 4294967295,
             # "sysState": 3,
             # "sysVer": 33620026,
@@ -257,8 +327,8 @@ class StreamAC(BaseDevice):
             .attr("minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
             .attr("maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
             # "waterInFlag": 0,
-
         ]
+
     # moduleWifiRssi
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return []
@@ -275,24 +345,37 @@ class StreamAC(BaseDevice):
     def _prepare_data(self, raw_data) -> dict[str, any]:
         raw = {"params": {}}
         from .proto import stream_ac_pb2 as stream_ac, stream_ac_pb2 as stream_ac2
+
         try:
             payload = raw_data
 
             while payload:
-                _LOGGER.debug("payload \"%s\"", payload.hex())
+                _LOGGER.debug('payload "%s"', payload.hex())
                 packet = stream_ac.SendHeaderStreamMsg()
                 used_bytes = packet.MergeFromString(payload)
 
-                if hasattr(packet.msg, "pdata") :
-                    _LOGGER.debug("cmd id \"%u\" fct id \"%u\" content \"%s\" - pdata:\"%s\"", packet.msg.cmd_id, packet.msg.cmd_func, str(packet), str(packet.msg.pdata.hex()))
-                else :
-                    _LOGGER.debug("cmd id \"%u\" fct id \"%u\" content \"%s\"", packet.msg.cmd_id, str(packet))
+                if hasattr(packet.msg, "pdata"):
+                    _LOGGER.debug(
+                        'cmd id "%u" fct id "%u" content "%s" - pdata:"%s"',
+                        packet.msg.cmd_id,
+                        packet.msg.cmd_func,
+                        str(packet),
+                        str(packet.msg.pdata.hex()),
+                    )
+                else:
+                    _LOGGER.debug(
+                        'cmd id "%u" fct id "%u" content "%s"',
+                        packet.msg.cmd_id,
+                        str(packet),
+                    )
 
-                if packet.msg.cmd_id < 0: #packet.msg.cmd_id != 21 and packet.msg.cmd_id != 22 and packet.msg.cmd_id != 50:
+                if (
+                    packet.msg.cmd_id < 0
+                ):  # packet.msg.cmd_id != 21 and packet.msg.cmd_id != 22 and packet.msg.cmd_id != 50:
                     _LOGGER.info("Unsupported EcoPacket cmd id %u", packet.msg.cmd_id)
 
                 else:
-                    _LOGGER.debug("new payload \"%s\"",str(packet.msg.pdata.hex()))
+                    _LOGGER.debug('new payload "%s"', str(packet.msg.pdata.hex()))
                     # paquet HeaderStream
                     if packet.msg.cmd_id > 0:
                         self._parsedata(packet, stream_ac2.HeaderStream(), raw)
@@ -323,16 +406,25 @@ class StreamAC(BaseDevice):
 
         except Exception as error:
             _LOGGER.error(error)
-            _LOGGER.debug("raw_data : \"%s\"  raw_data.hex() : \"%s\"",str(raw_data),str(raw_data.hex()))
+            _LOGGER.debug(
+                'raw_data : "%s"  raw_data.hex() : "%s"',
+                str(raw_data),
+                str(raw_data.hex()),
+            )
         return raw
 
-    def _parsedata(self, packet, content, raw) :
+    def _parsedata(self, packet, content, raw):
         try:
-            if hasattr(packet.msg, "pdata") and len(packet.msg.pdata) > 0 :
+            if hasattr(packet.msg, "pdata") and len(packet.msg.pdata) > 0:
                 content.ParseFromString(packet.msg.pdata)
 
                 if len(str(content)) > 0:
-                    _LOGGER.debug("initial cmd id \"%u\" fct id \"%u\" msg \n\"%s\"", packet.msg.cmd_id, packet.msg.cmd_func, str(content))
+                    _LOGGER.debug(
+                        'initial cmd id "%u" fct id "%u" msg \n"%s"',
+                        packet.msg.cmd_id,
+                        packet.msg.cmd_func,
+                        str(content),
+                    )
 
                 for descriptor in content.DESCRIPTOR.fields:
                     if not content.HasField(descriptor.name):
@@ -342,4 +434,6 @@ class StreamAC(BaseDevice):
 
         except Exception as error:
             _LOGGER.debug(error)
-            _LOGGER.debug("Erreur parsing pour le flux : %s",str(packet.msg.pdata.hex()))
+            _LOGGER.debug(
+                "Erreur parsing pour le flux : %s", str(packet.msg.pdata.hex())
+            )

--- a/custom_components/ecoflow_cloud/devices/internal/wave2.py
+++ b/custom_components/ecoflow_cloud/devices/internal/wave2.py
@@ -2,41 +2,80 @@ from homeassistant.components.switch import SwitchEntity
 
 from custom_components.ecoflow_cloud.api import EcoflowApiClient
 from custom_components.ecoflow_cloud.devices import const, BaseDevice
-from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSelectEntity
+from custom_components.ecoflow_cloud.entities import (
+    BaseSensorEntity,
+    BaseNumberEntity,
+    BaseSelectEntity,
+)
 from custom_components.ecoflow_cloud.number import SetTempEntity
 from custom_components.ecoflow_cloud.select import DictSelectEntity
-from custom_components.ecoflow_cloud.sensor import LevelSensorEntity, RemainSensorEntity, TempSensorEntity, \
-    WattsSensorEntity, MilliCelsiusSensorEntity, CapacitySensorEntity, QuotaStatusSensorEntity
+from custom_components.ecoflow_cloud.sensor import (
+    LevelSensorEntity,
+    RemainSensorEntity,
+    TempSensorEntity,
+    WattsSensorEntity,
+    MilliCelsiusSensorEntity,
+    CapacitySensorEntity,
+    QuotaStatusSensorEntity,
+)
 
 
 class Wave2(BaseDevice):
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
             # Power and Battery Entities
-            LevelSensorEntity(client, self, "bms.soc", const.MAIN_BATTERY_LEVEL)
-            .attr("bms.remainCap", const.ATTR_REMAIN_CAPACITY, 0),
-            CapacitySensorEntity(client, self, "bms.remainCap", const.MAIN_REMAIN_CAPACITY, False),
-
+            LevelSensorEntity(client, self, "bms.soc", const.MAIN_BATTERY_LEVEL).attr(
+                "bms.remainCap", const.ATTR_REMAIN_CAPACITY, 0
+            ),
+            CapacitySensorEntity(
+                client, self, "bms.remainCap", const.MAIN_REMAIN_CAPACITY, False
+            ),
             TempSensorEntity(client, self, "bms.tmp", const.BATTERY_TEMP)
             .attr("bms.minCellTemp", const.ATTR_MIN_CELL_TEMP, 0)
             .attr("bms.maxCellTemp", const.ATTR_MAX_CELL_TEMP, 0),
-            TempSensorEntity(client, self, "bms.minCellTmp", const.MIN_CELL_TEMP, False),
-            TempSensorEntity(client, self, "bms.maxCellTmp", const.MAX_CELL_TEMP, False),
-
-            RemainSensorEntity(client, self, "pd.batChgRemain", const.CHARGE_REMAINING_TIME),
-            RemainSensorEntity(client, self, "pd.batDsgRemain", const.DISCHARGE_REMAINING_TIME),
-
+            TempSensorEntity(
+                client, self, "bms.minCellTmp", const.MIN_CELL_TEMP, False
+            ),
+            TempSensorEntity(
+                client, self, "bms.maxCellTmp", const.MAX_CELL_TEMP, False
+            ),
+            RemainSensorEntity(
+                client, self, "pd.batChgRemain", const.CHARGE_REMAINING_TIME
+            ),
+            RemainSensorEntity(
+                client, self, "pd.batDsgRemain", const.DISCHARGE_REMAINING_TIME
+            ),
             # heat pump
-            MilliCelsiusSensorEntity(client, self, "pd.condTemp", "Condensation temperature", False),
-            MilliCelsiusSensorEntity(client, self, "pd.heatEnv", "Return air temperature in condensation zone", False),
-            MilliCelsiusSensorEntity(client, self, "pd.coolEnv", "Air outlet temperature", False),
-            MilliCelsiusSensorEntity(client, self, "pd.evapTemp", "Evaporation temperature", False),
-            MilliCelsiusSensorEntity(client, self, "pd.motorOutTemp", "Exhaust temperature", False),
-            MilliCelsiusSensorEntity(client, self, "pd.airInTemp", "Evaporation zone return air temperature", False),
-
-            TempSensorEntity(client, self, "pd.coolTemp", "Air outlet temperature", False),
+            MilliCelsiusSensorEntity(
+                client, self, "pd.condTemp", "Condensation temperature", False
+            ),
+            MilliCelsiusSensorEntity(
+                client,
+                self,
+                "pd.heatEnv",
+                "Return air temperature in condensation zone",
+                False,
+            ),
+            MilliCelsiusSensorEntity(
+                client, self, "pd.coolEnv", "Air outlet temperature", False
+            ),
+            MilliCelsiusSensorEntity(
+                client, self, "pd.evapTemp", "Evaporation temperature", False
+            ),
+            MilliCelsiusSensorEntity(
+                client, self, "pd.motorOutTemp", "Exhaust temperature", False
+            ),
+            MilliCelsiusSensorEntity(
+                client,
+                self,
+                "pd.airInTemp",
+                "Evaporation zone return air temperature",
+                False,
+            ),
+            TempSensorEntity(
+                client, self, "pd.coolTemp", "Air outlet temperature", False
+            ),
             TempSensorEntity(client, self, "pd.envTemp", "Ambient temperature", False),
-
             # power (pd)
             WattsSensorEntity(client, self, "pd.mpptPwr", "PV input power"),
             WattsSensorEntity(client, self, "pd.batPwrOut", "Battery output power"),
@@ -45,44 +84,87 @@ class Wave2(BaseDevice):
             WattsSensorEntity(client, self, "pd.psdrPower ", "Power supply power"),
             WattsSensorEntity(client, self, "pd.sysPowerWatts", "System power"),
             WattsSensorEntity(client, self, "pd.batPower ", "Battery power"),
-
             # power (motor)
             WattsSensorEntity(client, self, "motor.power", "Motor operating power"),
-
             # power (power)
             WattsSensorEntity(client, self, "power.batPwrOut", "Battery output power"),
             WattsSensorEntity(client, self, "power.acPwrI", "AC input power"),
             WattsSensorEntity(client, self, "power.mpptPwr ", "PV input power"),
-
-            QuotaStatusSensorEntity(client, self)
+            QuotaStatusSensorEntity(client, self),
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return [
-            SetTempEntity(client, self, "pd.setTemp", "Set Temperature", 0, 40,
-                          lambda value: {"moduleType": 1, "operateType": "setTemp",
-                                         "sn": self.device_info.sn,
-                                         "params": {"setTemp": int(value)}}),
+            SetTempEntity(
+                client,
+                self,
+                "pd.setTemp",
+                "Set Temperature",
+                0,
+                40,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "setTemp",
+                    "sn": self.device_info.sn,
+                    "params": {"setTemp": int(value)},
+                },
+            ),
         ]
 
     def selects(self, client: EcoflowApiClient) -> list[BaseSelectEntity]:
         return [
-            DictSelectEntity(client, self, "pd.fanValue", const.FAN_MODE, const.FAN_MODE_OPTIONS,
-                             lambda value: {"moduleType": 1, "operateType": "fanValue",
-                                            "sn": self.device_info.sn,
-                                            "params": {"fanValue": value}}),
-            DictSelectEntity(client, self, "pd.mainMode", const.MAIN_MODE, const.MAIN_MODE_OPTIONS,
-                             lambda value: {"moduleType": 1, "operateType": "mainMode",
-                                            "sn": self.device_info.sn,
-                                            "params": {"mainMode": value}}),
-            DictSelectEntity(client, self, "pd.powerMode", const.REMOTE_MODE, const.REMOTE_MODE_OPTIONS,
-                             lambda value: {"moduleType": 1, "operateType": "powerMode",
-                                            "sn": self.device_info.sn,
-                                            "params": {"powerMode": value}}),
-            DictSelectEntity(client, self, "pd.subMode", const.POWER_SUB_MODE, const.POWER_SUB_MODE_OPTIONS,
-                             lambda value: {"moduleType": 1, "operateType": "subMode",
-                                            "sn": self.device_info.sn,
-                                            "params": {"subMode": value}}),
+            DictSelectEntity(
+                client,
+                self,
+                "pd.fanValue",
+                const.FAN_MODE,
+                const.FAN_MODE_OPTIONS,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "fanValue",
+                    "sn": self.device_info.sn,
+                    "params": {"fanValue": value},
+                },
+            ),
+            DictSelectEntity(
+                client,
+                self,
+                "pd.mainMode",
+                const.MAIN_MODE,
+                const.MAIN_MODE_OPTIONS,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "mainMode",
+                    "sn": self.device_info.sn,
+                    "params": {"mainMode": value},
+                },
+            ),
+            DictSelectEntity(
+                client,
+                self,
+                "pd.powerMode",
+                const.REMOTE_MODE,
+                const.REMOTE_MODE_OPTIONS,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "powerMode",
+                    "sn": self.device_info.sn,
+                    "params": {"powerMode": value},
+                },
+            ),
+            DictSelectEntity(
+                client,
+                self,
+                "pd.subMode",
+                const.POWER_SUB_MODE,
+                const.POWER_SUB_MODE_OPTIONS,
+                lambda value: {
+                    "moduleType": 1,
+                    "operateType": "subMode",
+                    "sn": self.device_info.sn,
+                    "params": {"subMode": value},
+                },
+            ),
         ]
 
     def switches(self, client: EcoflowApiClient) -> list[SwitchEntity]:

--- a/custom_components/ecoflow_cloud/devices/public/data_bridge.py
+++ b/custom_components/ecoflow_cloud/devices/public/data_bridge.py
@@ -27,7 +27,7 @@ def to_plain(raw_data: dict[str, any]) -> dict[str, any]:
         prefix += f"{prefix1}."
     elif "cmdFunc" in raw_data and "cmdId" in raw_data:
         prefix += f"{raw_data['cmdFunc']}_{raw_data['cmdId']}."
-    else :
+    else:
         prefix += ""
 
     if "param" in raw_data:

--- a/custom_components/ecoflow_cloud/devices/public/delta2.py
+++ b/custom_components/ecoflow_cloud/devices/public/delta2.py
@@ -13,5 +13,3 @@ class Delta2(InternalDelta2):
 
     def _status_sensor(self, client: EcoflowApiClient) -> StatusSensorEntity:
         return StatusSensorEntity(client, self)
-
-

--- a/custom_components/ecoflow_cloud/devices/public/delta2_max.py
+++ b/custom_components/ecoflow_cloud/devices/public/delta2_max.py
@@ -13,5 +13,3 @@ class Delta2Max(InternalDelta2Max):
 
     def _status_sensor(self, client: EcoflowApiClient) -> StatusSensorEntity:
         return StatusSensorEntity(client, self)
-
-

--- a/custom_components/ecoflow_cloud/devices/public/delta_pro.py
+++ b/custom_components/ecoflow_cloud/devices/public/delta_pro.py
@@ -78,7 +78,9 @@ class DeltaPro(BaseDevice):
             ),
             WattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),
             WattsSensorEntity(client, self, "pd.wattsOutSum", const.TOTAL_OUT_POWER),
-            MilliampSensorEntity(client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT),
+            MilliampSensorEntity(
+                client, self, "bmsMaster.amp", const.MAIN_BATTERY_CURRENT
+            ),
             InWattsSensorEntity(client, self, "inv.inputWatts", const.AC_IN_POWER),
             OutWattsSensorEntity(client, self, "inv.outputWatts", const.AC_OUT_POWER),
             InMilliVoltSensorEntity(client, self, "inv.acInVol", const.AC_IN_VOLT),
@@ -87,7 +89,9 @@ class DeltaPro(BaseDevice):
                 client, self, "mppt.inWatts", const.SOLAR_IN_POWER
             ),
             InVoltSolarSensorEntity(client, self, "mppt.inVol", const.SOLAR_IN_VOLTAGE),
-            InMilliampSolarSensorEntity(client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT),
+            InMilliampSolarSensorEntity(
+                client, self, "mppt.inAmp", const.SOLAR_IN_CURRENT
+            ),
             OutWattsDcSensorEntity(client, self, "mppt.outWatts", const.DC_OUT_POWER),
             OutVoltDcSensorEntity(client, self, "mppt.outVol", const.DC_OUT_VOLTAGE),
             OutWattsSensorEntity(

--- a/custom_components/ecoflow_cloud/devices/public/delta_pro_3.py
+++ b/custom_components/ecoflow_cloud/devices/public/delta_pro_3.py
@@ -7,6 +7,7 @@ class DeltaPro3(InternalDeltaPro3):
     def _status_sensor(self, client: EcoflowApiClient) -> StatusSensorEntity:
         return StatusSensorEntity(client, self)
 
+
 from ...entities import (
     BaseNumberEntity,
     BaseSelectEntity,
@@ -46,10 +47,18 @@ class DeltaPro3(BaseDevice):
                 client, self, "bmsDesignCap", const.MAIN_DESIGN_CAPACITY, False
             ),
             LevelSensorEntity(client, self, "bmsBattSoh", const.SOH),
-            RemainSensorEntity(client, self, "bmsChgRemTime", const.CHARGE_REMAINING_TIME),
-            RemainSensorEntity(client, self, "bmsDsgRemTime", const.DISCHARGE_REMAINING_TIME),
-            TempSensorEntity(client, self, "bmsMinCellTemp", const.MIN_CELL_TEMP, False),
-            TempSensorEntity(client, self, "bmsMaxCellTemp", const.MAX_CELL_TEMP, False),
+            RemainSensorEntity(
+                client, self, "bmsChgRemTime", const.CHARGE_REMAINING_TIME
+            ),
+            RemainSensorEntity(
+                client, self, "bmsDsgRemTime", const.DISCHARGE_REMAINING_TIME
+            ),
+            TempSensorEntity(
+                client, self, "bmsMinCellTemp", const.MIN_CELL_TEMP, False
+            ),
+            TempSensorEntity(
+                client, self, "bmsMaxCellTemp", const.MAX_CELL_TEMP, False
+            ),
             TempSensorEntity(client, self, "bmsMinMosTemp", const.MIN_MOS_TEMP, False),
             TempSensorEntity(client, self, "bmsMaxMosTemp", const.MAX_MOS_TEMP, False),
             LevelSensorEntity(client, self, "cmsBattSoc", const.COMBINED_BATTERY_LEVEL),
@@ -66,19 +75,41 @@ class DeltaPro3(BaseDevice):
             OutWattsSensorEntity(client, self, "powGet12v", const.DC_12V_OUT_POWER),
             OutWattsSensorEntity(client, self, "powGet24v", const.DC_24V_OUT_POWER),
             OutWattsSensorEntity(client, self, "powGetAcLvOut", const.AC_LV_OUT_POWER),
-            OutWattsSensorEntity(client, self, "powGetAcLvTt30Out", const.AC_LV_TT30_OUT_POWER),
+            OutWattsSensorEntity(
+                client, self, "powGetAcLvTt30Out", const.AC_LV_TT30_OUT_POWER
+            ),
             OutWattsSensorEntity(client, self, "powGet5p8", const.POWER_INOUT_PORT),
-            OutWattsSensorEntity(client, self, "powGetQcusb1", const.USB_QC_1_OUT_POWER),
-            OutWattsSensorEntity(client, self, "powGetQcusb2", const.USB_QC_2_OUT_POWER),
-            OutWattsSensorEntity(client, self, "powGet4p81", const.EXTRA_BATTERY_1_OUT_POWER),
-            OutWattsSensorEntity(client, self, "powGet4p82", const.EXTRA_BATTERY_2_OUT_POWER),
+            OutWattsSensorEntity(
+                client, self, "powGetQcusb1", const.USB_QC_1_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "powGetQcusb2", const.USB_QC_2_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "powGet4p81", const.EXTRA_BATTERY_1_OUT_POWER
+            ),
+            OutWattsSensorEntity(
+                client, self, "powGet4p82", const.EXTRA_BATTERY_2_OUT_POWER
+            ),
             FrequencySensorEntity(client, self, "acOutFreq", const.AC_FREQUENCY),
-            VoltSensorEntity(client, self, "plugInInfoPvHChgVolMax", const.PV_VOLTAGE, False),
-            AmpSensorEntity(client, self, "plugInInfoPvHChgAmpMax", const.PV_CURRENT, False),
-            VoltSensorEntity(client, self, "plugInInfoPvLChgVolMax", const.PV_VOLTAGE, False),
-            AmpSensorEntity(client, self, "plugInInfoPvLChgAmpMax", const.PV_CURRENT, False),
-            RemainSensorEntity(client, self, "cmsChgRemTime", const.CHARGE_REMAINING_TIME),
-            RemainSensorEntity(client, self, "cmsDsgRemTime", const.DISCHARGE_REMAINING_TIME),
+            VoltSensorEntity(
+                client, self, "plugInInfoPvHChgVolMax", const.PV_VOLTAGE, False
+            ),
+            AmpSensorEntity(
+                client, self, "plugInInfoPvHChgAmpMax", const.PV_CURRENT, False
+            ),
+            VoltSensorEntity(
+                client, self, "plugInInfoPvLChgVolMax", const.PV_VOLTAGE, False
+            ),
+            AmpSensorEntity(
+                client, self, "plugInInfoPvLChgAmpMax", const.PV_CURRENT, False
+            ),
+            RemainSensorEntity(
+                client, self, "cmsChgRemTime", const.CHARGE_REMAINING_TIME
+            ),
+            RemainSensorEntity(
+                client, self, "cmsDsgRemTime", const.DISCHARGE_REMAINING_TIME
+            ),
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:

--- a/custom_components/ecoflow_cloud/devices/public/powerkit.py
+++ b/custom_components/ecoflow_cloud/devices/public/powerkit.py
@@ -238,7 +238,9 @@ class PowerKit(BaseDevice):
                 const.SOLAR_AND_ALT_IN_POWER,
                 True,
             ),
-            MilliampSensorEntity(client, self, "batCurr", "Solar Battery Current", True),
+            MilliampSensorEntity(
+                client, self, "batCurr", "Solar Battery Current", True
+            ),
             MilliVoltSensorEntity(
                 client, self, "batVol", "Solar Battery Voltage", True
             ),
@@ -248,7 +250,9 @@ class PowerKit(BaseDevice):
             MilliVoltSensorEntity(
                 client, self, "pv1InVol", "Solar (2) In Voltage", True
             ),
-            MilliampSensorEntity(client, self, "pv1InCurr", "Solar (2) In Current", True),
+            MilliampSensorEntity(
+                client, self, "pv1InCurr", "Solar (2) In Current", True
+            ),
             MiscSensorEntity(client, self, "pv1ErrCode", "Solar (2) Error Code", True),
             MiscSensorEntity(client, self, "pv1_hot_out", "Solar (2) Hot Out", False),
             MiscSensorEntity(
@@ -281,7 +285,9 @@ class PowerKit(BaseDevice):
             MilliVoltSensorEntity(
                 client, self, "pv2InVol", "Solar (3) In Voltage", True
             ),
-            MilliampSensorEntity(client, self, "pv2InCurr", "Solar (3) In Current", True),
+            MilliampSensorEntity(
+                client, self, "pv2InCurr", "Solar (3) In Current", True
+            ),
             MiscSensorEntity(client, self, "pv2ErrCode", "Solar (3) Error Code", True),
             MiscSensorEntity(client, self, "pv2_hot_out", "Solar (3) Hot Out", False),
             MiscSensorEntity(
@@ -481,7 +487,9 @@ class PowerKit(BaseDevice):
                 client, self, "outVol", "AC Out Voltage", True
             ),  # 240070
             # MiscSensorEntity(client, "outVa", 'AC Out VA', True), # 361
-            MilliampSensorEntity(client, self, "outCurr", "AC Out Current", True),  # 2432
+            MilliampSensorEntity(
+                client, self, "outCurr", "AC Out Current", True
+            ),  # 2432
             MiscSensorEntity(client, self, "invType", "AC Inverter Type", False),  # 0
             FrequencySensorEntity(client, self, "inFreq", "AC In Frequency", True),  # 0
             OutWattsSensorEntity(client, self, "inWatts", "AC In Power", True),  # 0
@@ -495,7 +503,9 @@ class PowerKit(BaseDevice):
             OutWattsSensorEntity(
                 client, self, "ch2Watt", "AC Outlet Power", True
             ),  # 165
-            MilliampSensorEntity(client, self, "outAmp2", "AC Outlet Current", True),  # 0
+            MilliampSensorEntity(
+                client, self, "outAmp2", "AC Outlet Current", True
+            ),  # 0
             FrequencySensorEntity(
                 client,
                 self,

--- a/custom_components/ecoflow_cloud/devices/public/powerstream.py
+++ b/custom_components/ecoflow_cloud/devices/public/powerstream.py
@@ -245,7 +245,7 @@ class PowerStream(BaseDevice):
     @override
     def switches(self, client: EcoflowApiClient) -> Sequence[SwitchEntity]:
         return []
-    
+
     @override
     def selects(self, client: EcoflowApiClient) -> Sequence[SelectEntity]:
         return [

--- a/custom_components/ecoflow_cloud/devices/public/smart_home_panel_2.py
+++ b/custom_components/ecoflow_cloud/devices/public/smart_home_panel_2.py
@@ -1,10 +1,16 @@
 from ...api import EcoflowApiClient
 from ...sensor import WattsSensorEntity, InWattsSensorEntity, LevelSensorEntity
 from .. import BaseDevice, const
-from ...entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, BaseSelectEntity
+from ...entities import (
+    BaseSensorEntity,
+    BaseNumberEntity,
+    BaseSwitchEntity,
+    BaseSelectEntity,
+)
 from custom_components.ecoflow_cloud.switch import EnabledEntity
 from custom_components.ecoflow_cloud.select import DictSelectEntity
 from ...number import MaxBatteryLevelEntity, ChargingPowerEntity, MinBatteryLevelEntity
+
 
 class SmartHomePanel2(BaseDevice):
 
@@ -27,7 +33,7 @@ class SmartHomePanel2(BaseDevice):
             self._sensorsBatterie(client, 2),
             self._sensorsBatterie(client, 3),
         ]
-    
+
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return [
             MinBatteryLevelEntity(
@@ -40,7 +46,7 @@ class SmartHomePanel2(BaseDevice):
                 lambda value: {
                     "sn": self.device_info.sn,
                     "cmdCode": "PD303_APP_SET",
-                    "params": {"backupReserveSoc": value}
+                    "params": {"backupReserveSoc": value},
                 },
             ),
             ChargingPowerEntity(
@@ -53,7 +59,7 @@ class SmartHomePanel2(BaseDevice):
                 lambda value: {
                     "sn": self.device_info.sn,
                     "cmdCode": "PD303_APP_SET",
-                    "params": {"chargeWattPower": value}
+                    "params": {"chargeWattPower": value},
                 },
             ),
             MaxBatteryLevelEntity(
@@ -66,9 +72,9 @@ class SmartHomePanel2(BaseDevice):
                 lambda value: {
                     "sn": self.device_info.sn,
                     "cmdCode": "PD303_APP_SET",
-                    "params": {"foceChargeHight": value}
+                    "params": {"foceChargeHight": value},
                 },
-            )
+            ),
         ]
 
     def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
@@ -81,7 +87,7 @@ class SmartHomePanel2(BaseDevice):
                 lambda value: {
                     "sn": self.device_info.sn,
                     "cmdCode": "PD303_APP_SET",
-                    "params": {"epsModeInfo": value == 1}
+                    "params": {"epsModeInfo": value == 1},
                 },
             ),
             EnabledEntity(
@@ -92,7 +98,7 @@ class SmartHomePanel2(BaseDevice):
                 lambda value: {
                     "sn": self.device_info.sn,
                     "cmdCode": "PD303_APP_SET",
-                    "params": {"stormIsEnable": value == 1}
+                    "params": {"stormIsEnable": value == 1},
                 },
             ),
         ]
@@ -114,12 +120,14 @@ class SmartHomePanel2(BaseDevice):
                 lambda value: {
                     "sn": self.device_info.sn,
                     "cmdCode": "PD303_APP_SET",
-                    "params": {"smartBackupMode": value}
+                    "params": {"smartBackupMode": value},
                 },
-            )
+            ),
         ]
-    
-    def _selectsBatterieStatus(self, client: EcoflowApiClient, index: int) -> BaseSelectEntity:
+
+    def _selectsBatterieStatus(
+        self, client: EcoflowApiClient, index: int
+    ) -> BaseSelectEntity:
         return DictSelectEntity(
             client,
             self,
@@ -129,11 +137,13 @@ class SmartHomePanel2(BaseDevice):
             lambda value: {
                 "sn": self.device_info.sn,
                 "cmdCode": "PD303_APP_SET",
-                "params": {f"ch{index}EnableSet": value}
+                "params": {f"ch{index}EnableSet": value},
             },
         )
 
-    def _selectsBatterieForceCharge(self, client: EcoflowApiClient, index: int) -> BaseSelectEntity:
+    def _selectsBatterieForceCharge(
+        self, client: EcoflowApiClient, index: int
+    ) -> BaseSelectEntity:
         return DictSelectEntity(
             client,
             self,
@@ -143,15 +153,24 @@ class SmartHomePanel2(BaseDevice):
             lambda value: {
                 "sn": self.device_info.sn,
                 "cmdCode": "PD303_APP_SET",
-                "params": {f"ch{index}ForceCharge": value}
+                "params": {f"ch{index}ForceCharge": value},
             },
         )
 
     def _sensorsSwitch(self, client: EcoflowApiClient, index: int) -> BaseSensorEntity:
-        return WattsSensorEntity(client, self, f"'loadInfo.hall1Watt'[{index}]", f"Breaker {index} Energy")
-    
-    def _sensorsBatterie(self, client: EcoflowApiClient, index: int) -> BaseSensorEntity:
-        return LevelSensorEntity(client, self, f"'backupIncreInfo.Energy{index}Info.batteryPercentage'", f"Battery Level {index}")
+        return WattsSensorEntity(
+            client, self, f"'loadInfo.hall1Watt'[{index}]", f"Breaker {index} Energy"
+        )
+
+    def _sensorsBatterie(
+        self, client: EcoflowApiClient, index: int
+    ) -> BaseSensorEntity:
+        return LevelSensorEntity(
+            client,
+            self,
+            f"'backupIncreInfo.Energy{index}Info.batteryPercentage'",
+            f"Battery Level {index}",
+        )
 
     def flat_json(self):
         return False

--- a/custom_components/ecoflow_cloud/devices/public/smart_meter.py
+++ b/custom_components/ecoflow_cloud/devices/public/smart_meter.py
@@ -13,5 +13,3 @@ class SmartMeter(InternalSmartMeter):
 
     def _status_sensor(self, client: EcoflowApiClient) -> StatusSensorEntity:
         return StatusSensorEntity(client, self)
-
-

--- a/custom_components/ecoflow_cloud/devices/public/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/public/stream_ac.py
@@ -2,24 +2,45 @@ from ...api import EcoflowApiClient
 from ...sensor import StatusSensorEntity
 from .data_bridge import to_plain
 from custom_components.ecoflow_cloud.devices import const, BaseDevice
-from custom_components.ecoflow_cloud.entities import BaseSensorEntity, BaseNumberEntity, BaseSwitchEntity, \
-    BaseSelectEntity
-from custom_components.ecoflow_cloud.sensor import WattsSensorEntity,LevelSensorEntity,CapacitySensorEntity, \
-    InWattsSensorEntity,OutWattsSensorEntity, RemainSensorEntity, MilliVoltSensorEntity, TempSensorEntity, \
-    CyclesSensorEntity, EnergySensorEntity, CumulativeCapacitySensorEntity
+from custom_components.ecoflow_cloud.entities import (
+    BaseSensorEntity,
+    BaseNumberEntity,
+    BaseSwitchEntity,
+    BaseSelectEntity,
+)
+from custom_components.ecoflow_cloud.sensor import (
+    WattsSensorEntity,
+    LevelSensorEntity,
+    CapacitySensorEntity,
+    InWattsSensorEntity,
+    OutWattsSensorEntity,
+    RemainSensorEntity,
+    MilliVoltSensorEntity,
+    TempSensorEntity,
+    CyclesSensorEntity,
+    EnergySensorEntity,
+    CumulativeCapacitySensorEntity,
+)
+
 
 class StreamAC(BaseDevice):
 
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
             # "accuChgCap": 198511,
-            CumulativeCapacitySensorEntity(client, self, "accuChgCap", const.ACCU_CHARGE_CAP, False),
+            CumulativeCapacitySensorEntity(
+                client, self, "accuChgCap", const.ACCU_CHARGE_CAP, False
+            ),
             # "accuChgEnergy": 3992,
             EnergySensorEntity(client, self, "accuChgEnergy", const.ACCU_CHARGE_ENERGY),
             # "accuDsgCap": 184094,
-            CumulativeCapacitySensorEntity(client, self, "accuDsgCap", const.ACCU_DISCHARGE_CAP, False),
+            CumulativeCapacitySensorEntity(
+                client, self, "accuDsgCap", const.ACCU_DISCHARGE_CAP, False
+            ),
             # "accuDsgEnergy": 3646,
-            EnergySensorEntity(client, self, "accuDsgEnergy", const.ACCU_DISCHARGE_ENERGY),
+            EnergySensorEntity(
+                client, self, "accuDsgEnergy", const.ACCU_DISCHARGE_ENERGY
+            ),
             # "actSoc": 46.0,
             # "amp": 44671,
             # "backupReverseSoc": 5,
@@ -32,10 +53,14 @@ class StreamAC(BaseDevice):
             # "bmsBattSoh": 100.0,
             # "bmsChgDsgState": 2,
             # "bmsChgRemTime": 88,
-            RemainSensorEntity(client, self, "bmsChgRemTime", const.CHARGE_REMAINING_TIME, False),
+            RemainSensorEntity(
+                client, self, "bmsChgRemTime", const.CHARGE_REMAINING_TIME, False
+            ),
             # "bmsDesignCap": 1920,
             # "bmsDsgRemTime": 5939,
-            RemainSensorEntity(client, self, "bmsDsgRemTime", const.DISCHARGE_REMAINING_TIME, False),
+            RemainSensorEntity(
+                client, self, "bmsDsgRemTime", const.DISCHARGE_REMAINING_TIME, False
+            ),
             # "bmsFault": 0,
             # "bmsFaultState": 0,
             # "bmsHeartbeatVer": 260,
@@ -77,7 +102,9 @@ class StreamAC(BaseDevice):
             # "cycles": 1,
             CyclesSensorEntity(client, self, "cycles", const.CYCLES),
             # "designCap": 100000,
-            CapacitySensorEntity(client, self, "designCap", const.STREAM_DESIGN_CAPACITY,False),
+            CapacitySensorEntity(
+                client, self, "designCap", const.STREAM_DESIGN_CAPACITY, False
+            ),
             # "devCtrlStatus": 1,
             # "devSleepState": 0,
             # "diffSoc": 0.2050476,
@@ -91,20 +118,28 @@ class StreamAC(BaseDevice):
             # "energyStrategyOperateMode.operateSelfPoweredOpen": true,
             # "energyStrategyOperateMode.operateTouModeOpen": false,
             # "f32ShowSoc": 46.317574,
-            LevelSensorEntity(client, self, "f32ShowSoc", const.STREAM_POWER_BATTERY_SOC),
+            LevelSensorEntity(
+                client, self, "f32ShowSoc", const.STREAM_POWER_BATTERY_SOC
+            ),
             # "feedGridMode": 2,
             # "feedGridModePowLimit": 800,
             # "feedGridModePowMax": 800,
             # "fullCap": 100000,
-            CapacitySensorEntity(client, self, "fullCap", const.STREAM_FULL_CAPACITY, False),
+            CapacitySensorEntity(
+                client, self, "fullCap", const.STREAM_FULL_CAPACITY, False
+            ),
             # "gridCodeSelection": "GRID_STD_CODE_UTE_MAINLAND",
             # "gridCodeVersion": 10001,
             # "gridConnectionFreq": 49.974655,
             # "gridConnectionPower": -967.2364,
-            WattsSensorEntity(client, self, "gridConnectionPower", const.STREAM_POWER_AC),
+            WattsSensorEntity(
+                client, self, "gridConnectionPower", const.STREAM_POWER_AC
+            ),
             # "gridConnectionSta": "PANEL_GRID_IN",
             # "gridConnectionVol": 235.34576,
-            MilliVoltSensorEntity(client, self, "gridConnectionVol", const.STREAM_POWER_VOL, False),
+            MilliVoltSensorEntity(
+                client, self, "gridConnectionVol", const.STREAM_POWER_VOL, False
+            ),
             # "gridSysDeviceCnt": 2,
             # "heatfilmNtcNum": 0,
             # "heatfilmTemp": [],
@@ -117,7 +152,9 @@ class StreamAC(BaseDevice):
             # "maxCellTemp": 35,
             TempSensorEntity(client, self, "maxCellTemp", const.MAX_CELL_TEMP, False),
             # "maxCellVol": 3362,
-            MilliVoltSensorEntity(client, self, "maxCellVol", const.MAX_CELL_VOLT, False),
+            MilliVoltSensorEntity(
+                client, self, "maxCellVol", const.MAX_CELL_VOLT, False
+            ),
             # "maxCurSensorTemp": 0,
             # "maxEnvTemp": 0,
             # "maxHeatfilmTemp": 0,
@@ -130,7 +167,9 @@ class StreamAC(BaseDevice):
             # "minCellTemp": 33,
             TempSensorEntity(client, self, "minCellTemp", const.MIN_CELL_TEMP, False),
             # "minCellVol": 3357,
-            MilliVoltSensorEntity(client, self, "minCellVol", const.MIN_CELL_VOLT, False),
+            MilliVoltSensorEntity(
+                client, self, "minCellVol", const.MIN_CELL_VOLT, False
+            ),
             # "minCurSensorTemp": 0,
             # "minEnvTemp": 0,
             # "minHeatfilmTemp": 0,
@@ -159,29 +198,50 @@ class StreamAC(BaseDevice):
             # "powGetBpCms": 1915.0862,
             WattsSensorEntity(client, self, "powGetBpCms", const.STREAM_POWER_BATTERY),
             # "powGetPv": 0.0,
-            WattsSensorEntity(client, self, "powGetPv", const.STREAM_POWER_PV_1, False, True),
+            WattsSensorEntity(
+                client, self, "powGetPv", const.STREAM_POWER_PV_1, False, True
+            ),
             # "powGetPv2": 0.0,
-            WattsSensorEntity(client, self, "powGetPv2", const.STREAM_POWER_PV_2, False, True),
+            WattsSensorEntity(
+                client, self, "powGetPv2", const.STREAM_POWER_PV_2, False, True
+            ),
             # "powGetPv3": 0.0,
-            WattsSensorEntity(client, self, "powGetPv3", const.STREAM_POWER_PV_3, False, True),
+            WattsSensorEntity(
+                client, self, "powGetPv3", const.STREAM_POWER_PV_3, False, True
+            ),
             # "powGetPv4": 0.0,
-            WattsSensorEntity(client, self, "powGetPv4", const.STREAM_POWER_PV_4, False, True),
+            WattsSensorEntity(
+                client, self, "powGetPv4", const.STREAM_POWER_PV_4, False, True
+            ),
             # "powGetPvSum": 2051.3975,
             WattsSensorEntity(client, self, "powGetPvSum", const.STREAM_POWER_PV_SUM),
             # "powGetSchuko1": 0.0,
-            WattsSensorEntity(client, self, "powGetSchuko1", const.STREAM_GET_SCHUKO1, False, True),
+            WattsSensorEntity(
+                client, self, "powGetSchuko1", const.STREAM_GET_SCHUKO1, False, True
+            ),
             # "powGetSchuko2": 18.654325,
-            WattsSensorEntity(client, self, "powGetSchuko2", const.STREAM_GET_SCHUKO2, False, True),
+            WattsSensorEntity(
+                client, self, "powGetSchuko2", const.STREAM_GET_SCHUKO2, False, True
+            ),
             # "powGetSysGrid": -135.0,
             WattsSensorEntity(client, self, "powGetSysGrid", const.STREAM_POWER_GRID),
             # "powGetSysLoad": 0.0,
             WattsSensorEntity(client, self, "powGetSysLoad", const.STREAM_GET_SYS_LOAD),
             # "powGetSysLoadFromBp": 0.0,
-            WattsSensorEntity(client, self, "powGetSysLoadFromBp", const.STREAM_GET_SYS_LOAD_FROM_BP),
+            WattsSensorEntity(
+                client, self, "powGetSysLoadFromBp", const.STREAM_GET_SYS_LOAD_FROM_BP
+            ),
             # "powGetSysLoadFromGrid": 0.0,
-            WattsSensorEntity(client, self, "powGetSysLoadFromGrid", const.STREAM_GET_SYS_LOAD_FROM_GRID),
+            WattsSensorEntity(
+                client,
+                self,
+                "powGetSysLoadFromGrid",
+                const.STREAM_GET_SYS_LOAD_FROM_GRID,
+            ),
             # "powGetSysLoadFromPv": 0.0,
-            WattsSensorEntity(client, self, "powGetSysLoadFromPv", const.STREAM_GET_SYS_LOAD_FROM_PV),
+            WattsSensorEntity(
+                client, self, "powGetSysLoadFromPv", const.STREAM_GET_SYS_LOAD_FROM_PV
+            ),
             # "powSysAcInMax": 4462,
             # "powSysAcOutMax": 800,
             # "productDetail": 5,
@@ -193,7 +253,9 @@ class StreamAC(BaseDevice):
             # "relay3Onoff": true,
             # "relay4Onoff": true,
             # "remainCap": 46317,
-            CapacitySensorEntity(client, self, "remainCap", const.STREAM_REMAIN_CAPACITY,False),
+            CapacitySensorEntity(
+                client, self, "remainCap", const.STREAM_REMAIN_CAPACITY, False
+            ),
             # "remainTime": 88,
             RemainSensorEntity(client, self, "remainTime", const.REMAINING_TIME),
             # "runtimePropertyFullUploadPeriod": 120000,
@@ -212,7 +274,9 @@ class StreamAC(BaseDevice):
             # "stormPatternEndTime": 0,
             # "stormPatternOpenFlag": false,
             # "sysGridConnectionPower": -2020.0437,
-            WattsSensorEntity(client, self, "sysGridConnectionPower", const.STREAM_POWER_AC_SYS),
+            WattsSensorEntity(
+                client, self, "sysGridConnectionPower", const.STREAM_POWER_AC_SYS
+            ),
             # "sysLoaderVer": 4294967295,
             # "sysState": 3,
             # "sysVer": 33620026,
@@ -256,8 +320,8 @@ class StreamAC(BaseDevice):
             .attr("minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
             .attr("maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
             # "waterInFlag": 0,
-
         ]
+
     # moduleWifiRssi
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return []
@@ -275,5 +339,3 @@ class StreamAC(BaseDevice):
 
     def _status_sensor(self, client: EcoflowApiClient) -> StatusSensorEntity:
         return StatusSensorEntity(client, self)
-
-

--- a/custom_components/ecoflow_cloud/devices/public/stream_microinverter.py
+++ b/custom_components/ecoflow_cloud/devices/public/stream_microinverter.py
@@ -21,23 +21,39 @@ class StreamMicroinveter(BaseDevice):
 
     def sensors(self, client: EcoflowApiClient) -> list[BaseSensorEntity]:
         return [
-            WattsSensorEntity(client, self, "gridConnectionPower", const.STREAM_POWER_AC),
-            WattsSensorEntity(client, self, "powGetPv", const.STREAM_POWER_PV_1, False, True),
-            WattsSensorEntity(client, self, "powGetPv2", const.STREAM_POWER_PV_2, False, True),
-
-            VoltSensorEntity(client, self, "gridConnectionVol", const.STREAM_POWER_VOL, False),
-            VoltSensorEntity(client, self, "plugInInfoPvVol", const.STREAM_IN_VOL_PV_1, False, True),
-            VoltSensorEntity(client, self, "plugInInfoPv2Vol", const.STREAM_IN_VOL_PV_2, False, True),
-
-            InAmpSensorEntity(client, self, "gridConnectionAmp", const.STREAM_POWER_AMP, False),
-            InAmpSensorEntity(client, self, "plugInInfoPvAmp", const.STREAM_IN_AMPS_PV_1, False, True),
-            InAmpSensorEntity(client, self, "plugInInfoPv2Amp", const.STREAM_IN_AMPS_PV_2, False, True),
-
-            CelsiusSensorEntity(client, self, "invNtcTemp3", "Inverter NTC Temperature"),
+            WattsSensorEntity(
+                client, self, "gridConnectionPower", const.STREAM_POWER_AC
+            ),
+            WattsSensorEntity(
+                client, self, "powGetPv", const.STREAM_POWER_PV_1, False, True
+            ),
+            WattsSensorEntity(
+                client, self, "powGetPv2", const.STREAM_POWER_PV_2, False, True
+            ),
+            VoltSensorEntity(
+                client, self, "gridConnectionVol", const.STREAM_POWER_VOL, False
+            ),
+            VoltSensorEntity(
+                client, self, "plugInInfoPvVol", const.STREAM_IN_VOL_PV_1, False, True
+            ),
+            VoltSensorEntity(
+                client, self, "plugInInfoPv2Vol", const.STREAM_IN_VOL_PV_2, False, True
+            ),
+            InAmpSensorEntity(
+                client, self, "gridConnectionAmp", const.STREAM_POWER_AMP, False
+            ),
+            InAmpSensorEntity(
+                client, self, "plugInInfoPvAmp", const.STREAM_IN_AMPS_PV_1, False, True
+            ),
+            InAmpSensorEntity(
+                client, self, "plugInInfoPv2Amp", const.STREAM_IN_AMPS_PV_2, False, True
+            ),
+            CelsiusSensorEntity(
+                client, self, "invNtcTemp3", "Inverter NTC Temperature"
+            ),
             FrequencySensorEntity(client, self, "gridConnectionFreq", "Grid Frequency"),
-            StatusSensorEntity(client, self)
+            StatusSensorEntity(client, self),
         ]
-
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:
         return []
@@ -55,5 +71,3 @@ class StreamMicroinveter(BaseDevice):
 
     def _status_sensor(self, client: EcoflowApiClient) -> StatusSensorEntity:
         return StatusSensorEntity(client, self)
-
-

--- a/custom_components/ecoflow_cloud/devices/registry.py
+++ b/custom_components/ecoflow_cloud/devices/registry.py
@@ -84,7 +84,7 @@ device_by_product: OrderedDict[str, Type[BaseDevice]] = OrderedDict[
         "Stream AC": public_stream_ac.StreamAC,
         "Stream PRO": public_stream_ac.StreamAC,
         "Stream Ultra": public_stream_ac.StreamAC,
-        "Stream Microinverter" : public_stream_microinverter.StreamMicroinveter,
+        "Stream Microinverter": public_stream_microinverter.StreamMicroinveter,
         "Smart Home Panel 2": public_smart_home_panel_2.SmartHomePanel2,
         "Diagnostic": DiagnosticDevice,
     }

--- a/custom_components/ecoflow_cloud/diagnostics.py
+++ b/custom_components/ecoflow_cloud/diagnostics.py
@@ -18,18 +18,18 @@ def _to_serializable(x):
 
 async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigEntry):
     client: EcoflowApiClient = hass.data[ECOFLOW_DOMAIN][entry.entry_id]
-    values = {"EcoFlow":[]}
-    for (sn, device) in client.devices.items():
+    values = {"EcoFlow": []}
+    for sn, device in client.devices.items():
         value = {
-            'device':    device.device_info.device_type,
-            'name':      device.device_info.name,
-            'sn':        sn,
-            'params':    dict(sorted(device.data.params.items())),
-            'set':       [dict(sorted(k.items())) for k in device.data.set],
-            'set_reply': [dict(sorted(k.items())) for k in device.data.set_reply],
-            'get':       [dict(sorted(k.items())) for k in device.data.get],
-            'get_reply': [dict(sorted(k.items())) for k in device.data.get_reply],
-            'raw_data': device.data.raw_data,
+            "device": device.device_info.device_type,
+            "name": device.device_info.name,
+            "sn": sn,
+            "params": dict(sorted(device.data.params.items())),
+            "set": [dict(sorted(k.items())) for k in device.data.set],
+            "set_reply": [dict(sorted(k.items())) for k in device.data.set_reply],
+            "get": [dict(sorted(k.items())) for k in device.data.get],
+            "get_reply": [dict(sorted(k.items())) for k in device.data.get_reply],
+            "raw_data": device.data.raw_data,
         }
         values["EcoFlow"].append(value)
     return values

--- a/custom_components/ecoflow_cloud/entities/__init__.py
+++ b/custom_components/ecoflow_cloud/entities/__init__.py
@@ -153,9 +153,11 @@ class EcoFlowBaseCommandEntity[_CommandArg](EcoFlowDictEntity):
         device: BaseDevice,
         mqtt_key: str,
         title: str,
-        command: Callable[[_CommandArg], dict[str, Any] | Message]
-        | Callable[[_CommandArg, dict[str, Any]], dict[str, Any] | Message]
-        | None,
+        command: (
+            Callable[[_CommandArg], dict[str, Any] | Message]
+            | Callable[[_CommandArg, dict[str, Any]], dict[str, Any] | Message]
+            | None
+        ),
         enabled: bool = True,
         auto_enable: bool = False,
     ):
@@ -197,9 +199,11 @@ class BaseNumberEntity(NumberEntity, EcoFlowBaseCommandEntity[int]):
         title: str,
         min_value: int,
         max_value: int,
-        command: Callable[[int], dict[str, Any] | Message]
-        | Callable[[int, dict[str, Any]], dict[str, Any] | Message]
-        | None,
+        command: (
+            Callable[[int], dict[str, Any] | Message]
+            | Callable[[int, dict[str, Any]], dict[str, Any] | Message]
+            | None
+        ),
         enabled: bool = True,
         auto_enable: bool = False,
     ):

--- a/custom_components/ecoflow_cloud/number.py
+++ b/custom_components/ecoflow_cloud/number.py
@@ -44,9 +44,11 @@ class ChargingPowerEntity(ValueUpdateEntity):
         title: str,
         min_value: int,
         max_value: int,
-        command: Callable[[int], dict[str, Any] | Message]
-        | Callable[[int, dict[str, Any]], dict[str, Any] | Message]
-        | None,
+        command: (
+            Callable[[int], dict[str, Any] | Message]
+            | Callable[[int, dict[str, Any]], dict[str, Any] | Message]
+            | None
+        ),
         enabled: bool = True,
         auto_enable: bool = False,
     ):
@@ -97,9 +99,11 @@ class MinMaxLevelEntity(ValueUpdateEntity):
         title: str,
         min_value: int,
         max_value: int,
-        command: Callable[[int], dict[str, Any] | Message]
-        | Callable[[int, dict[str, Any]], dict[str, Any] | Message]
-        | None,
+        command: (
+            Callable[[int], dict[str, Any] | Message]
+            | Callable[[int, dict[str, Any]], dict[str, Any] | Message]
+            | None
+        ),
     ):
         super().__init__(
             client, device, mqtt_key, title, min_value, max_value, command, True, False

--- a/custom_components/ecoflow_cloud/select.py
+++ b/custom_components/ecoflow_cloud/select.py
@@ -30,9 +30,11 @@ class DictSelectEntity(BaseSelectEntity[int]):
         mqtt_key: str,
         title: str,
         options: dict[str, Any],
-        command: Callable[[int], dict[str, Any] | Message]
-        | Callable[[int, dict[str, Any]], dict[str, Any] | Message]
-        | None,
+        command: (
+            Callable[[int], dict[str, Any] | Message]
+            | Callable[[int, dict[str, Any]], dict[str, Any] | Message]
+            | None
+        ),
         enabled: bool = True,
         auto_enable: bool = False,
     ):

--- a/custom_components/ecoflow_cloud/switch.py
+++ b/custom_components/ecoflow_cloud/switch.py
@@ -32,9 +32,11 @@ class EnabledEntity(BaseSwitchEntity[int]):
         device: BaseDevice,
         mqtt_key: str,
         title: str,
-        command: Callable[[int], dict[str, Any] | Message]
-        | Callable[[int, dict[str, Any]], dict[str, Any] | Message]
-        | None,
+        command: (
+            Callable[[int], dict[str, Any] | Message]
+            | Callable[[int, dict[str, Any]], dict[str, Any] | Message]
+            | None
+        ),
         enabled: bool = True,
         auto_enable: bool = False,
         enableValue: Any = None,

--- a/debug.init.py
+++ b/debug.init.py
@@ -15,34 +15,30 @@ _LOGGER = logging.getLogger(__name__)
 loop = asyncio.new_event_loop()
 asyncio.set_event_loop(loop)
 
+
 async def main():
 
-    data = MappingProxyType(
-        {
-            "type": "powerkit",
-            "device_id": os.environ['ecoflowSn']
-        }
-    )
+    data = MappingProxyType({"type": "powerkit", "device_id": os.environ["ecoflowSn"]})
 
     config = ConfigEntry(
-        version='1.0.0',
-        minor_version='1',
-        domain='homeassistant.local',
-        title='debugEcoflow',
+        version="1.0.0",
+        minor_version="1",
+        domain="homeassistant.local",
+        title="debugEcoflow",
         data=data,
-        source='',
-        options= MappingProxyType(
-        {
-            "refresh_period_sec": 1
-        })
+        source="",
+        options=MappingProxyType({"refresh_period_sec": 1}),
     )
-    auth = EcoflowAuthentication(os.environ['ecoflowUserName'], os.environ['ecoflowPassword'])
+    auth = EcoflowAuthentication(
+        os.environ["ecoflowUserName"], os.environ["ecoflowPassword"]
+    )
     auth.authorize()
-    home = HomeAssistant('./')
+    home = HomeAssistant("./")
     client = EcoflowMQTTClient(home, config, auth)
     powerkit = PowerKit()
     sensors = powerkit.sensors(client)
     client.data.params_observable().subscribe(lambda v: updateSensors(v))
+
     def updateSensors(data: dict[str, any]):
         for v in sensors:
             v.hass = home
@@ -51,5 +47,7 @@ async def main():
             _LOGGER.info(v._attr_native_value)
 
     while True:
-            await asyncio.sleep(1)
+        await asyncio.sleep(1)
+
+
 asyncio.run(main())

--- a/docs/gen.py
+++ b/docs/gen.py
@@ -4,7 +4,9 @@ from unittest.mock import Mock
 
 from custom_components.ecoflow_cloud.device_data import DeviceData, DeviceOptions
 from custom_components.ecoflow_cloud.devices import BaseDevice, EcoflowDeviceInfo
-from custom_components.ecoflow_cloud.devices.internal.proto.support.message import ProtoMessage
+from custom_components.ecoflow_cloud.devices.internal.proto.support.message import (
+    ProtoMessage,
+)
 from custom_components.ecoflow_cloud.devices.registry import (
     devices,
     device_by_product,
@@ -109,7 +111,7 @@ def prepare_options(options: dict[str, Any]) -> str:
 
 def prepare_command(e: EcoFlowBaseCommandEntity) -> str | None:
     command_dict = e.command_dict(MARKER_VALUE)
-    if command_dict is not None:       
+    if command_dict is not None:
         if isinstance(command_dict, dict):
             json_dict = command_dict
         elif isinstance(command_dict, ProtoMessage):


### PR DESCRIPTION
## Summary
- run `black` over the project to make formatting consistent
- increase polling speed and optimize parsing of incoming protobuf messages

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688272d65a34832fbb2039f4847ed973