### PR TITLE
Fix Delta Pro 3 charging speed max

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
@@ -235,7 +235,7 @@ class DeltaPro3(BaseDevice):
             ChargingPowerEntity(
                 client,
                 self,
-                "cfgPlugInInfoAcInChgPowMax",
+                "plugInInfoAcInChgPowMax",
                 const.AC_CHARGING_POWER,
                 400,
                 2900,
@@ -246,7 +246,7 @@ class DeltaPro3(BaseDevice):
                     "dirSrc": 1,
                     "cmdFunc": 254,
                     "dest": 2,
-                    "params": {"cfgPlugInInfoAcInChgPowMax": value},
+                    "params": {"plugInInfoAcInChgPowMax": value},
                 },
             ),
         ]

--- a/custom_components/ecoflow_cloud/devices/public/delta_pro_3.py
+++ b/custom_components/ecoflow_cloud/devices/public/delta_pro_3.py
@@ -209,7 +209,7 @@ class DeltaPro3(BaseDevice):
             ChargingPowerEntity(
                 client,
                 self,
-                "cfgPlugInInfoAcInChgPowMax",
+                "plugInInfoAcInChgPowMax",
                 const.AC_CHARGING_POWER,
                 400,
                 2900,
@@ -220,7 +220,7 @@ class DeltaPro3(BaseDevice):
                     "dirSrc": 1,
                     "cmdFunc": 254,
                     "dest": 2,
-                    "params": {"cfgPlugInInfoAcInChgPowMax": value},
+                    "params": {"plugInInfoAcInChgPowMax": value},
                 },
             ),
         ]

--- a/docs/devices/Delta_Pro_3-Public.md
+++ b/docs/devices/Delta_Pro_3-Public.md
@@ -38,7 +38,7 @@
 - Backup Reserve Level (`cfgEnergyBackup.energyBackupStartSoc` -> `{"sn": "SN", "cmdId": 17, "dirDest": 1, "dirSrc": 1, "cmdFunc": 254, "dest": 2, "params": {"cfgEnergyBackup": {"energyBackupStartSoc": "VALUE", "energyBackupEn": true}}}` [5 - 100])
 - Generator Auto Start Level (`cfgCmsOilOnSoc` -> `{"sn": "SN", "cmdId": 17, "dirDest": 1, "dirSrc": 1, "cmdFunc": 254, "dest": 2, "params": {"cfgCmsOilOnSoc": "VALUE"}}` [0 - 30])
 - Generator Auto Stop Level (`cfgCmsOilOffSoc` -> `{"sn": "SN", "cmdId": 17, "dirDest": 1, "dirSrc": 1, "cmdFunc": 254, "dest": 2, "params": {"cfgCmsOilOffSoc": "VALUE"}}` [50 - 100])
-- AC Charging Power (`cfgPlugInInfoAcInChgPowMax` -> `{"sn": "SN", "cmdId": 17, "dirDest": 1, "dirSrc": 1, "cmdFunc": 254, "dest": 2, "params": {"cfgPlugInInfoAcInChgPowMax": "VALUE"}}` [400 - 2900])
+- AC Charging Power (`plugInInfoAcInChgPowMax` -> `{"sn": "SN", "cmdId": 17, "dirDest": 1, "dirSrc": 1, "cmdFunc": 254, "dest": 2, "params": {"plugInInfoAcInChgPowMax": "VALUE"}}` [400 - 2900])
 
 *Selects*
 


### PR DESCRIPTION
## Summary
- correct maximum limit for AC charging power

## Testing
- `python -m py_compile custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py custom_components/ecoflow_cloud/devices/public/delta_pro_3.py`


------
https://chatgpt.com/codex/tasks/task_e_68831cbbd260832fb706f96c9c18741f