### PR TITLE
Make EnergyStore I/O asynchronous

### DIFF
--- a/custom_components/ecoflow_cloud/__init__.py
+++ b/custom_components/ecoflow_cloud/__init__.py
@@ -194,7 +194,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     if "energy_store" not in hass.data[ECOFLOW_DOMAIN]:
         from .energy_store import EnergyStore
 
-        hass.data[ECOFLOW_DOMAIN]["energy_store"] = EnergyStore(hass)
+        hass.data[ECOFLOW_DOMAIN]["energy_store"] = await EnergyStore.async_create(
+            hass
+        )
 
     for sn, device_data in devices_list.items():
         device = api_client.configure_device(device_data)

--- a/custom_components/ecoflow_cloud/energy_store.py
+++ b/custom_components/ecoflow_cloud/energy_store.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import json
 import logging
 from homeassistant.core import HomeAssistant
@@ -6,32 +7,46 @@ from homeassistant.core import HomeAssistant
 _LOGGER = logging.getLogger(__name__)
 
 class EnergyStore:
-    def __init__(self, hass: HomeAssistant):
+    def __init__(self, hass: HomeAssistant) -> None:
         self._hass = hass
         self._path = hass.config.path("ecoflow_energy.json")
         self._data: dict[str, dict[str, float | str]] = {}
-        self._load()
 
-    def _load(self) -> None:
+    @classmethod
+    async def async_create(cls, hass: HomeAssistant) -> "EnergyStore":
+        """Create a store and load data asynchronously."""
+        store = cls(hass)
+        await store.async_load()
+        return store
+
+    def _load_sync(self) -> dict[str, dict[str, float | str]]:
         try:
             with open(self._path, "r", encoding="utf-8") as f:
-                self._data = json.load(f)
+                return json.load(f)
         except FileNotFoundError:
-            self._data = {}
+            return {}
         except Exception as err:
             _LOGGER.error("Failed to load energy store: %s", err)
-            self._data = {}
+            return {}
 
-    def save(self) -> None:
+    async def async_load(self) -> None:
+        """Load data from disk without blocking the event loop."""
+        self._data = await self._hass.async_add_executor_job(self._load_sync)
+
+    def _save_sync(self) -> None:
         try:
             with open(self._path, "w", encoding="utf-8") as f:
                 json.dump(self._data, f)
         except Exception as err:
             _LOGGER.error("Failed to save energy store: %s", err)
 
+    async def async_save(self) -> None:
+        """Save data to disk without blocking the event loop."""
+        await self._hass.async_add_executor_job(self._save_sync)
+
     def get(self, key: str, default: dict[str, float | str] | None = None):
         return self._data.get(key, default)
 
     def set(self, key: str, value: dict[str, float | str]) -> None:
         self._data[key] = value
-        self.save()
+        self._hass.async_create_task(self.async_save())

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -56,7 +56,9 @@ async def async_setup_entry(
 ):
     client: EcoflowApiClient = hass.data[ECOFLOW_DOMAIN][entry.entry_id]
     if "energy_store" not in hass.data[ECOFLOW_DOMAIN]:
-        hass.data[ECOFLOW_DOMAIN]["energy_store"] = EnergyStore(hass)
+        hass.data[ECOFLOW_DOMAIN]["energy_store"] = await EnergyStore.async_create(
+            hass
+        )
     store: EnergyStore = hass.data[ECOFLOW_DOMAIN]["energy_store"]
     for sn, device in client.devices.items():
         sensors = list(device.sensors(client))


### PR DESCRIPTION
## Summary
- make EnergyStore async friendly using executor jobs
- create the store asynchronously in sensor and init setup

## Testing
- `python -m py_compile custom_components/ecoflow_cloud/*.py custom_components/ecoflow_cloud/entities/*.py`

------
https://chatgpt.com/codex/tasks/task_e_68837b355b6c832faa9499453ef47eca