### PR TITLE
Improve energy store saving

### DIFF
--- a/custom_components/ecoflow_cloud/__init__.py
+++ b/custom_components/ecoflow_cloud/__init__.py
@@ -220,6 +220,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     client = hass.data[ECOFLOW_DOMAIN].pop(entry.entry_id)
     client.stop()
     await client.close()
+    store = hass.data[ECOFLOW_DOMAIN].get("energy_store")
+    if store is not None:
+        await store.async_close()
     return True
 
 


### PR DESCRIPTION
## Summary
- serialize energy store updates with a lock
- ensure save task only runs once per batch
- cancel pending energy store task when unloading

## Testing
- `ruff check custom_components/ecoflow_cloud/energy_store.py custom_components/ecoflow_cloud/__init__.py`
- `python -m py_compile custom_components/ecoflow_cloud/energy_store.py custom_components/ecoflow_cloud/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6883829cb3a8832f8b6c2503fb3eaa39