### PR TITLE
Fix inverter energy for Delta Pro 3

### DIFF
--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -152,7 +152,12 @@ async def async_setup_entry(
             const.POWER_INOUT_PORT_ENERGY: [const.POWER_INOUT_PORT],
             const.EXTRA_BATTERY_1_ENERGY: [const.EXTRA_BATTERY_1_OUT_POWER],
             const.EXTRA_BATTERY_2_ENERGY: [const.EXTRA_BATTERY_2_OUT_POWER],
-            const.INVERTER_OUT_ENERGY: [const.AC_OUT_POWER],
+            const.INVERTER_OUT_ENERGY: [
+                const.AC_OUT_POWER,
+                const.AC_HV_OUT_POWER,
+                const.AC_LV_OUT_POWER,
+                const.AC_LV_TT30_OUT_POWER,
+            ],
             const.TYPEC_OUT_ENERGY: [
                 const.TYPEC_OUT_POWER,
                 const.TYPEC_1_OUT_POWER,


### PR DESCRIPTION
## Summary
- include high/low voltage AC power sensors in inverter energy calculation

## Testing
- `pip install hassfest` *(fails: repository requires auth)*

------
https://chatgpt.com/codex/tasks/task_e_688513c1bcf8832f9a96e0a143f18705