### PR TITLE
Handle negative inverter power

### DIFF
--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -583,7 +583,8 @@ class CalculatedEnergySensorEntity(BaseSensorEntity):
         for expr, scale in zip(self._keys, self._scales):
             values = expr.find(params)
             if len(values) == 1:
-                total += float(values[0].value) * scale
+                value = float(values[0].value) * scale
+                total += abs(value)
                 found = True
         if not found:
             return


### PR DESCRIPTION
## Summary
- account for negative values when summing inverter output energy

## Testing
- `pre-commit` *(fails: `.pre-commit-config.yaml` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688522ad8748832f91264e0f3eff3bee