### PR TITLE
Add local MQTT server option

### DIFF
--- a/custom_components/ecoflow_cloud/api/__init__.py
+++ b/custom_components/ecoflow_cloud/api/__init__.py
@@ -22,6 +22,7 @@ class EcoflowMqttInfo:
     username: str
     password: str
     client_id: str | None = None
+    ssl: bool = True
 
 
 class EcoflowApiClient(ABC):

--- a/custom_components/ecoflow_cloud/api/ecoflow_mqtt.py
+++ b/custom_components/ecoflow_cloud/api/ecoflow_mqtt.py
@@ -34,8 +34,9 @@ class EcoflowMQTTClient:
         self.__client.username_pw_set(
             self.__mqtt_info.username, self.__mqtt_info.password
         )
-        self.__client.tls_set(certfile=None, keyfile=None, cert_reqs=ssl.CERT_REQUIRED)
-        self.__client.tls_insecure_set(False)
+        if self.__mqtt_info.ssl:
+            self.__client.tls_set(certfile=None, keyfile=None, cert_reqs=ssl.CERT_REQUIRED)
+            self.__client.tls_insecure_set(False)
         self.__client.on_connect = self._on_connect
         self.__client.on_disconnect = self._on_disconnect
         self.__client.on_message = self._on_message


### PR DESCRIPTION
## Summary
- allow overriding MQTT host/port/SSL via configuration
- add migration step for new MQTT settings
- respect SSL flag when connecting
- expose option in config flow to set local broker

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6885dc3e53f8832f8ac554fd2407029d