### PR TITLE
Add spike protection for Delta Pro 3 energy sensors

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
@@ -25,9 +25,9 @@ from custom_components.ecoflow_cloud.sensor import (
     VoltSensorEntity,
     AmpSensorEntity,
     FrequencySensorEntity,
-    InEnergySensorEntity,
-    InEnergySolarSensorEntity,
-    OutEnergySensorEntity,
+    InProtectedEnergySensorEntity,
+    InProtectedEnergySolarSensorEntity,
+    OutProtectedEnergySensorEntity,
 )
 from custom_components.ecoflow_cloud.switch import BeeperEntity, EnabledEntity
 from custom_components.ecoflow_cloud.devices import BaseDevice, const
@@ -132,15 +132,15 @@ class DeltaPro3(BaseDevice):
             OutWattsSensorEntity(
                 client, self, "powGet4p82", const.EXTRA_BATTERY_2_OUT_POWER
             ),
-            InEnergySensorEntity(client, self, "powGetAcIn", const.AC_IN_ENERGY),
-            InEnergySolarSensorEntity(client, self, "powGetPvL", const.SOLAR_IN_ENERGY),
-            InEnergySensorEntity(client, self, "powGetPvH", const.PV_HV_ENERGY),
-            OutEnergySensorEntity(client, self, "powGet5p8", const.POWER_INOUT_PORT_ENERGY),
-            OutEnergySensorEntity(client, self, "powGet4p81", const.EXTRA_BATTERY_1_ENERGY),
-            OutEnergySensorEntity(client, self, "powGet4p82", const.EXTRA_BATTERY_2_ENERGY),
-            OutEnergySensorEntity(client, self, "powGetAc", const.DISCHARGE_AC_ENERGY),
-            InEnergySensorEntity(client, self, "powInSumW", const.TOTAL_IN_ENERGY),
-            OutEnergySensorEntity(client, self, "powOutSumW", const.TOTAL_OUT_ENERGY),
+            InProtectedEnergySensorEntity(client, self, "powGetAcIn", const.AC_IN_ENERGY),
+            InProtectedEnergySolarSensorEntity(client, self, "powGetPvL", const.SOLAR_IN_ENERGY),
+            InProtectedEnergySensorEntity(client, self, "powGetPvH", const.PV_HV_ENERGY),
+            OutProtectedEnergySensorEntity(client, self, "powGet5p8", const.POWER_INOUT_PORT_ENERGY),
+            OutProtectedEnergySensorEntity(client, self, "powGet4p81", const.EXTRA_BATTERY_1_ENERGY),
+            OutProtectedEnergySensorEntity(client, self, "powGet4p82", const.EXTRA_BATTERY_2_ENERGY),
+            OutProtectedEnergySensorEntity(client, self, "powGetAc", const.DISCHARGE_AC_ENERGY),
+            InProtectedEnergySensorEntity(client, self, "powInSumW", const.TOTAL_IN_ENERGY),
+            OutProtectedEnergySensorEntity(client, self, "powOutSumW", const.TOTAL_OUT_ENERGY),
             FrequencySensorEntity(client, self, "acOutFreq", const.AC_FREQUENCY),
             VoltSensorEntity(
                 client, self, "plugInInfoPvHChgVolMax", const.PV_VOLTAGE, False


### PR DESCRIPTION
## Summary
- add mixin that rejects unrealistic energy meter jumps
- use protected energy sensors for Delta Pro 3

## Testing
- `python -m py_compile custom_components/ecoflow_cloud/sensor.py custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887c5c54c94832fb3f3e7eee4ad1cbc