### PR TITLE
Add protected energy sensors across devices

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta_max.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_max.py
@@ -26,8 +26,9 @@ from custom_components.ecoflow_cloud.sensor import (
     OutMilliVoltSensorEntity,
     CapacitySensorEntity,
     InWattsSolarSensorEntity,
-    InEnergySensorEntity,
-    OutEnergySensorEntity,
+    InProtectedEnergySensorEntity,
+    InProtectedEnergySolarSensorEntity,
+    OutProtectedEnergySensorEntity,
     OutWattsDcSensorEntity,
     QuotaStatusSensorEntity,
     StatusSensorEntity,
@@ -136,13 +137,13 @@ class DeltaMax(BaseDevice):
             MilliVoltSensorEntity(
                 client, self, "bmsMaster.maxCellVol", const.MAX_CELL_VOLT, False
             ),
-            InEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
-            InEnergySensorEntity(client, self, "pd.chgPowerAc", const.CHARGE_AC_ENERGY),
-            InEnergySensorEntity(client, self, "pd.chgPowerDc", const.CHARGE_DC_ENERGY),
-            OutEnergySensorEntity(
+            InProtectedEnergySolarSensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
+            InProtectedEnergySensorEntity(client, self, "pd.chgPowerAc", const.CHARGE_AC_ENERGY),
+            InProtectedEnergySensorEntity(client, self, "pd.chgPowerDc", const.CHARGE_DC_ENERGY),
+            OutProtectedEnergySensorEntity(
                 client, self, "pd.dsgPowerAc", const.DISCHARGE_AC_ENERGY
             ),
-            OutEnergySensorEntity(
+            OutProtectedEnergySensorEntity(
                 client, self, "pd.dsgPowerDc", const.DISCHARGE_DC_ENERGY
             ),
             # Optional Slave Batteries

--- a/custom_components/ecoflow_cloud/devices/internal/delta_mini.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_mini.py
@@ -28,8 +28,9 @@ from custom_components.ecoflow_cloud.sensor import (
     OutMilliVoltSensorEntity,
     CapacitySensorEntity,
     InWattsSolarSensorEntity,
-    InEnergySensorEntity,
-    OutEnergySensorEntity,
+    InProtectedEnergySensorEntity,
+    InProtectedEnergySolarSensorEntity,
+    OutProtectedEnergySensorEntity,
     OutWattsDcSensorEntity,
     QuotaStatusSensorEntity,
     MilliampSensorEntity,
@@ -130,13 +131,13 @@ class DeltaMini(BaseDevice):
             )
             .attr("bmsMaster.minCellVol", const.ATTR_MIN_CELL_VOLT, 0)
             .attr("bmsMaster.maxCellVol", const.ATTR_MAX_CELL_VOLT, 0),
-            InEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
-            InEnergySensorEntity(client, self, "pd.chgPowerAc", const.CHARGE_AC_ENERGY),
-            InEnergySensorEntity(client, self, "pd.chgPowerDc", const.CHARGE_DC_ENERGY),
-            OutEnergySensorEntity(
+            InProtectedEnergySolarSensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
+            InProtectedEnergySensorEntity(client, self, "pd.chgPowerAc", const.CHARGE_AC_ENERGY),
+            InProtectedEnergySensorEntity(client, self, "pd.chgPowerDc", const.CHARGE_DC_ENERGY),
+            OutProtectedEnergySensorEntity(
                 client, self, "pd.dsgPowerAc", const.DISCHARGE_AC_ENERGY
             ),
-            OutEnergySensorEntity(
+            OutProtectedEnergySensorEntity(
                 client, self, "pd.dsgPowerDc", const.DISCHARGE_DC_ENERGY
             ),
             QuotaStatusSensorEntity(client, self),

--- a/custom_components/ecoflow_cloud/devices/internal/delta_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_pro.py
@@ -30,8 +30,9 @@ from custom_components.ecoflow_cloud.sensor import (
     OutMilliVoltSensorEntity,
     CapacitySensorEntity,
     InWattsSolarSensorEntity,
-    InEnergySensorEntity,
-    OutEnergySensorEntity,
+    InProtectedEnergySensorEntity,
+    InProtectedEnergySolarSensorEntity,
+    OutProtectedEnergySensorEntity,
     OutWattsDcSensorEntity,
     QuotaStatusSensorEntity,
     MilliampSensorEntity,
@@ -144,13 +145,13 @@ class DeltaPro(BaseDevice):
             MilliVoltSensorEntity(
                 client, self, "bmsMaster.maxCellVol", const.MAX_CELL_VOLT, False
             ),
-            InEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
-            InEnergySensorEntity(client, self, "pd.chgPowerAc", const.CHARGE_AC_ENERGY),
-            InEnergySensorEntity(client, self, "pd.chgPowerDc", const.CHARGE_DC_ENERGY),
-            OutEnergySensorEntity(
+            InProtectedEnergySolarSensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
+            InProtectedEnergySensorEntity(client, self, "pd.chgPowerAc", const.CHARGE_AC_ENERGY),
+            InProtectedEnergySensorEntity(client, self, "pd.chgPowerDc", const.CHARGE_DC_ENERGY),
+            OutProtectedEnergySensorEntity(
                 client, self, "pd.dsgPowerAc", const.DISCHARGE_AC_ENERGY
             ),
-            OutEnergySensorEntity(
+            OutProtectedEnergySensorEntity(
                 client, self, "pd.dsgPowerDc", const.DISCHARGE_DC_ENERGY
             ),
             # Optional Slave Batteries

--- a/custom_components/ecoflow_cloud/devices/internal/river_max.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river_max.py
@@ -14,9 +14,10 @@ from custom_components.ecoflow_cloud.sensor import (
     RemainSensorEntity,
     TempSensorEntity,
     CyclesSensorEntity,
-    InEnergySensorEntity,
+    InProtectedEnergySensorEntity,
+    InProtectedEnergySolarSensorEntity,
     InWattsSensorEntity,
-    OutEnergySensorEntity,
+    OutProtectedEnergySensorEntity,
     OutWattsSensorEntity,
     InMilliampSensorEntity,
     MilliampSensorEntity,
@@ -95,13 +96,13 @@ class RiverMax(BaseDevice):
             ),
             TempSensorEntity(client, self, "inv.inTemp", const.INV_IN_TEMP),
             TempSensorEntity(client, self, "inv.outTemp", const.INV_OUT_TEMP),
-            InEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
-            InEnergySensorEntity(client, self, "pd.chgPowerAC", const.CHARGE_AC_ENERGY),
-            InEnergySensorEntity(client, self, "pd.chgPowerDC", const.CHARGE_DC_ENERGY),
-            OutEnergySensorEntity(
+            InProtectedEnergySolarSensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
+            InProtectedEnergySensorEntity(client, self, "pd.chgPowerAC", const.CHARGE_AC_ENERGY),
+            InProtectedEnergySensorEntity(client, self, "pd.chgPowerDC", const.CHARGE_DC_ENERGY),
+            OutProtectedEnergySensorEntity(
                 client, self, "pd.dsgPowerAC", const.DISCHARGE_AC_ENERGY
             ),
-            OutEnergySensorEntity(
+            OutProtectedEnergySensorEntity(
                 client, self, "pd.dsgPowerDC", const.DISCHARGE_DC_ENERGY
             ),
             # Optional Slave Batteries

--- a/custom_components/ecoflow_cloud/devices/internal/river_mini.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river_mini.py
@@ -12,9 +12,10 @@ from custom_components.ecoflow_cloud.sensor import (
     WattsSensorEntity,
     TempSensorEntity,
     CyclesSensorEntity,
-    InEnergySensorEntity,
+    InProtectedEnergySensorEntity,
+    InProtectedEnergySolarSensorEntity,
     InWattsSensorEntity,
-    OutEnergySensorEntity,
+    OutProtectedEnergySensorEntity,
     OutWattsSensorEntity,
     MilliampSensorEntity,
     InMilliVoltSensorEntity,
@@ -39,13 +40,13 @@ class RiverMini(BaseDevice):
             MilliampSensorEntity(client, self, "inv.dcInAmp", const.SOLAR_IN_CURRENT),
             TempSensorEntity(client, self, "inv.inTemp", const.INV_IN_TEMP),
             TempSensorEntity(client, self, "inv.outTemp", const.INV_OUT_TEMP),
-            InEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
-            InEnergySensorEntity(client, self, "pd.chgPowerAC", const.CHARGE_AC_ENERGY),
-            InEnergySensorEntity(client, self, "pd.chgPowerDC", const.CHARGE_DC_ENERGY),
-            OutEnergySensorEntity(
+            InProtectedEnergySolarSensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
+            InProtectedEnergySensorEntity(client, self, "pd.chgPowerAC", const.CHARGE_AC_ENERGY),
+            InProtectedEnergySensorEntity(client, self, "pd.chgPowerDC", const.CHARGE_DC_ENERGY),
+            OutProtectedEnergySensorEntity(
                 client, self, "pd.dsgPowerAC", const.DISCHARGE_AC_ENERGY
             ),
-            OutEnergySensorEntity(
+            OutProtectedEnergySensorEntity(
                 client, self, "pd.dsgPowerDC", const.DISCHARGE_DC_ENERGY
             ),
             WattsSensorEntity(client, self, "pd.wattsInSum", const.TOTAL_IN_POWER),

--- a/custom_components/ecoflow_cloud/devices/internal/river_pro.py
+++ b/custom_components/ecoflow_cloud/devices/internal/river_pro.py
@@ -14,9 +14,10 @@ from custom_components.ecoflow_cloud.sensor import (
     RemainSensorEntity,
     TempSensorEntity,
     CyclesSensorEntity,
-    InEnergySensorEntity,
+    InProtectedEnergySensorEntity,
+    InProtectedEnergySolarSensorEntity,
     InWattsSensorEntity,
-    OutEnergySensorEntity,
+    OutProtectedEnergySensorEntity,
     OutWattsSensorEntity,
     InMilliampSensorEntity,
     MilliampSensorEntity,
@@ -90,13 +91,13 @@ class RiverPro(BaseDevice):
             ),
             TempSensorEntity(client, self, "inv.inTemp", const.INV_IN_TEMP),
             TempSensorEntity(client, self, "inv.outTemp", const.INV_OUT_TEMP),
-            InEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
-            InEnergySensorEntity(client, self, "pd.chgPowerAC", const.CHARGE_AC_ENERGY),
-            InEnergySensorEntity(client, self, "pd.chgPowerDC", const.CHARGE_DC_ENERGY),
-            OutEnergySensorEntity(
+            InProtectedEnergySolarSensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
+            InProtectedEnergySensorEntity(client, self, "pd.chgPowerAC", const.CHARGE_AC_ENERGY),
+            InProtectedEnergySensorEntity(client, self, "pd.chgPowerDC", const.CHARGE_DC_ENERGY),
+            OutProtectedEnergySensorEntity(
                 client, self, "pd.dsgPowerAC", const.DISCHARGE_AC_ENERGY
             ),
-            OutEnergySensorEntity(
+            OutProtectedEnergySensorEntity(
                 client, self, "pd.dsgPowerDC", const.DISCHARGE_DC_ENERGY
             ),
             # Optional Slave Batteries

--- a/custom_components/ecoflow_cloud/devices/public/delta_pro.py
+++ b/custom_components/ecoflow_cloud/devices/public/delta_pro.py
@@ -18,14 +18,15 @@ from ...sensor import (
     CapacitySensorEntity,
     CyclesSensorEntity,
     InMilliampSolarSensorEntity,
-    InEnergySensorEntity,
+    InProtectedEnergySensorEntity,
+    InProtectedEnergySolarSensorEntity,
     InMilliVoltSensorEntity,
     InVoltSolarSensorEntity,
     InWattsSensorEntity,
     InWattsSolarSensorEntity,
     LevelSensorEntity,
     MilliVoltSensorEntity,
-    OutEnergySensorEntity,
+    OutProtectedEnergySensorEntity,
     OutMilliVoltSensorEntity,
     OutVoltDcSensorEntity,
     OutWattsDcSensorEntity,
@@ -141,13 +142,13 @@ class DeltaPro(BaseDevice):
             MilliVoltSensorEntity(
                 client, self, "bmsMaster.maxCellVol", const.MAX_CELL_VOLT, False
             ),
-            InEnergySensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
-            InEnergySensorEntity(client, self, "pd.chgPowerAc", const.CHARGE_AC_ENERGY),
-            InEnergySensorEntity(client, self, "pd.chgPowerDc", const.CHARGE_DC_ENERGY),
-            OutEnergySensorEntity(
+            InProtectedEnergySolarSensorEntity(client, self, "pd.chgSunPower", const.SOLAR_IN_ENERGY),
+            InProtectedEnergySensorEntity(client, self, "pd.chgPowerAc", const.CHARGE_AC_ENERGY),
+            InProtectedEnergySensorEntity(client, self, "pd.chgPowerDc", const.CHARGE_DC_ENERGY),
+            OutProtectedEnergySensorEntity(
                 client, self, "pd.dsgPowerAc", const.DISCHARGE_AC_ENERGY
             ),
-            OutEnergySensorEntity(
+            OutProtectedEnergySensorEntity(
                 client, self, "pd.dsgPowerDc", const.DISCHARGE_DC_ENERGY
             ),
             # Optional Slave Batteries


### PR DESCRIPTION
## Summary
- use `InProtectedEnergySensorEntity` and `OutProtectedEnergySensorEntity` in device modules
- prefer `InProtectedEnergySolarSensorEntity` for solar charging energy

## Testing
- `python -m compileall custom_components`

------
https://chatgpt.com/codex/tasks/task_e_6887c9e7685c832fa790ff4aad7c7026