### PR TITLE
Improve Delta Pro 3 status updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,6 +419,7 @@ This repository is a fork of the original project by tolwi — I really apprecia
 - PV Current  _(disabled)_
 - Charge Remaining Time
 - Discharge Remaining Time
+- Status
 
 *Switches*
 - Beeper 
@@ -1947,7 +1948,7 @@ This repository is a fork of the original project by tolwi — I really apprecia
 
 </p></details>
 
-<details><summary> Delta Pro 3 (API) <i>(sensors: 36, switches: 4, sliders: 6, selects: 0)</i> </summary>
+<details><summary> Delta Pro 3 (API) <i>(sensors: 37, switches: 4, sliders: 6, selects: 0)</i> </summary>
 <p>
 
 *Sensors*

--- a/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta_pro_3.py
@@ -28,6 +28,7 @@ from custom_components.ecoflow_cloud.sensor import (
     InProtectedEnergySensorEntity,
     InProtectedEnergySolarSensorEntity,
     OutProtectedEnergySensorEntity,
+    QuotaStatusSensorEntity,
 )
 from custom_components.ecoflow_cloud.switch import BeeperEntity, EnabledEntity
 from custom_components.ecoflow_cloud.devices import BaseDevice, const
@@ -160,6 +161,7 @@ class DeltaPro3(BaseDevice):
             RemainSensorEntity(
                 client, self, "cmsDsgRemTime", const.DISCHARGE_REMAINING_TIME
             ),
+            QuotaStatusSensorEntity(client, self),
         ]
 
     def numbers(self, client: EcoflowApiClient) -> list[BaseNumberEntity]:

--- a/docs/devices/Delta_Pro_3-Public.md
+++ b/docs/devices/Delta_Pro_3-Public.md
@@ -34,6 +34,7 @@
 - Total In Energy (`powInSumW`)
 - Total Out Energy (`powOutSumW`)
 - Total Energy (`powInSumW` + `powOutSumW`)
+- Status
 
 
 *Switches*

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -403,6 +403,7 @@
 - PV Current  _(disabled)_
 - Charge Remaining Time
 - Discharge Remaining Time
+- Status
 
 *Switches*
 - Beeper 
@@ -1931,7 +1932,7 @@
 
 </p></details>
 
-<details><summary> Delta Pro 3 (API) <i>(sensors: 36, switches: 4, sliders: 6, selects: 0)</i> </summary>
+<details><summary> Delta Pro 3 (API) <i>(sensors: 37, switches: 4, sliders: 6, selects: 0)</i> </summary>
 <p>
 
 *Sensors*


### PR DESCRIPTION
## Summary
- poll for quotas on Delta Pro 3 by adding QuotaStatusSensorEntity
- document the new Status sensor for Delta Pro 3

## Testing
- `python3 -m homeassistant.scripts.hassfest --help` *(fails: ModuleNotFoundError: josepy has no attribute ComparableX509)*

------
https://chatgpt.com/codex/tasks/task_e_6888618c3610832fa1b38e0cb464e7c7