### PR TITLE
Add Delta 3 Plus device support

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta3_plus.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta3_plus.py
@@ -1,0 +1,7 @@
+from .delta3 import Delta3
+
+
+class Delta3Plus(Delta3):
+    """Device class for Delta 3 Plus. Currently identical to Delta3."""
+
+    pass

--- a/custom_components/ecoflow_cloud/devices/public/delta3_plus.py
+++ b/custom_components/ecoflow_cloud/devices/public/delta3_plus.py
@@ -1,0 +1,16 @@
+from ...api import EcoflowApiClient
+from ...sensor import StatusSensorEntity
+from ..internal.delta3_plus import Delta3Plus as InternalDelta3Plus
+from .data_bridge import to_plain
+
+
+class Delta3Plus(InternalDelta3Plus):
+    """Public API device class for Delta 3 Plus."""
+
+    def _prepare_data(self, raw_data) -> dict[str, any]:
+        res = super()._prepare_data(raw_data)
+        res = to_plain(res)
+        return res
+
+    def _status_sensor(self, client: EcoflowApiClient) -> StatusSensorEntity:
+        return StatusSensorEntity(client, self)

--- a/custom_components/ecoflow_cloud/devices/registry.py
+++ b/custom_components/ecoflow_cloud/devices/registry.py
@@ -3,6 +3,7 @@ from typing import Type, OrderedDict
 from .internal import (
     delta2 as internal_delta2,
     delta3 as internal_delta3,
+    delta3_plus as internal_delta3_plus,
     river2 as internal_river2,
     river2_max as internal_river2_max,
     river2_pro as internal_river2_pro,
@@ -25,6 +26,7 @@ from .public import (
     delta2 as public_delta2,
     delta2_max as public_delta2_max,
     delta3 as public_delta3,
+    delta3_plus as public_delta3_plus,
     river2 as public_river2,
     river2_max as public_river2_max,
     river2_pro as public_river2_pro,
@@ -45,6 +47,7 @@ devices: OrderedDict[str, Type[BaseDevice]] = OrderedDict[str, Type[BaseDevice]]
     {
         "DELTA_2": internal_delta2.Delta2,
         "DELTA_3": internal_delta3.Delta3,
+        "DELTA_3_PLUS": internal_delta3_plus.Delta3Plus,
         "RIVER_2": internal_river2.River2,
         "RIVER_2_MAX": internal_river2_max.River2Max,
         "RIVER_2_PRO": internal_river2_pro.River2Pro,
@@ -76,6 +79,7 @@ device_by_product: OrderedDict[str, Type[BaseDevice]] = OrderedDict[
         "DELTA 2": public_delta2.Delta2,
         "DELTA 2 Max": public_delta2_max.Delta2Max,
         "DELTA 3": public_delta3.Delta3,
+        "Delta 3 Plus": public_delta3_plus.Delta3Plus,
         "RIVER 2": public_river2.River2,
         "RIVER 2 Max": public_river2_max.River2Max,
         "RIVER 2 Pro": public_river2_pro.River2Pro,


### PR DESCRIPTION
## Summary
- implement `Delta3Plus` classes for internal and public APIs
- register device to allow adding Delta 3 Plus in Home Assistant

## Testing
- `python3 -m py_compile custom_components/ecoflow_cloud/devices/internal/delta3_plus.py custom_components/ecoflow_cloud/devices/public/delta3_plus.py custom_components/ecoflow_cloud/devices/registry.py`

------
https://chatgpt.com/codex/tasks/task_e_68888d50fb5c832f8c074819574554a1