### PR TITLE
Add AC/DC toggle for Delta 3 Plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -2007,7 +2007,7 @@ This repository is a fork of the original project by tolwi — I really apprecia
 
 </p></details>
 
-<details><summary> Delta 3 Plus (API) <i>(sensors: 17, switches: 7, sliders: 3, selects: 0)</i> </summary>
+<details><summary> Delta 3 Plus (API) <i>(sensors: 17, switches: 8, sliders: 3, selects: 0)</i> </summary>
 <p>
 
 *Sensors*
@@ -2031,6 +2031,7 @@ This repository is a fork of the original project by tolwi — I really apprecia
 
 *Switches*
 - X-Boost Enabled
+- AC Enabled
 - AC Always On
 - DC Enabled
 - USB Enabled

--- a/custom_components/ecoflow_cloud/devices/internal/delta3_plus.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta3_plus.py
@@ -1,7 +1,38 @@
+from custom_components.ecoflow_cloud.api import EcoflowApiClient
+from custom_components.ecoflow_cloud.devices import const
+from custom_components.ecoflow_cloud.entities import BaseSwitchEntity
+from custom_components.ecoflow_cloud.switch import EnabledEntity
 from .delta3 import Delta3
+from .delta_pro_3 import DeltaPro3SetMessage
 
 
 class Delta3Plus(Delta3):
-    """Device class for Delta 3 Plus. Currently identical to Delta3."""
+    """Device class for Delta 3 Plus."""
 
-    pass
+    def switches(self, client: EcoflowApiClient) -> list[BaseSwitchEntity]:
+        switches = super().switches(client)
+        switches.extend(
+            [
+                EnabledEntity(
+                    client,
+                    self,
+                    "mppt.cfgAcEnabled",
+                    const.AC_ENABLED,
+                    lambda value: DeltaPro3SetMessage(
+                        self.device_info.sn, "cfgAcOutOpen", value
+                    ),
+                    enableValue=2,
+                ),
+                EnabledEntity(
+                    client,
+                    self,
+                    "pd.carState",
+                    const.DC_ENABLED,
+                    lambda value: DeltaPro3SetMessage(
+                        self.device_info.sn, "cfgDc12vOutOpen", value
+                    ),
+                    enableValue=2,
+                ),
+            ]
+        )
+        return switches

--- a/docs/devices/Delta_3_Plus-Public.md
+++ b/docs/devices/Delta_3_Plus-Public.md
@@ -88,6 +88,7 @@ message Delta3PlusHeartbeat {
 
 *Switches*
 - X-Boost Enabled
+- AC Enabled
 - AC Always On
 - DC Enabled
 - USB Enabled

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -2000,7 +2000,7 @@
 
 </p></details>
 
-<details><summary> Delta 3 Plus (API) <i>(sensors: 17, switches: 7, sliders: 3, selects: 0)</i> </summary>
+<details><summary> Delta 3 Plus (API) <i>(sensors: 17, switches: 8, sliders: 3, selects: 0)</i> </summary>
 <p>
 
 *Sensors*
@@ -2024,6 +2024,7 @@
 
 *Switches*
 - X-Boost Enabled
+- AC Enabled
 - AC Always On
 - DC Enabled
 - USB Enabled


### PR DESCRIPTION
## Summary
- support AC/DC switching via protobuf for Delta 3 Plus
- document new AC Enabled switch

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68889433a64c832f8371cf57da8b1cf0