### PR TITLE
Fix Delta3Plus AC/DC switches

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta3_plus.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta3_plus.py
@@ -16,17 +16,17 @@ class Delta3Plus(Delta3):
                 EnabledEntity(
                     client,
                     self,
-                    "mppt.cfgAcEnabled",
+                    "flowInfoAcHvOut",
                     const.AC_ENABLED,
                     lambda value: DeltaPro3SetMessage(
-                        self.device_info.sn, "cfgAcOutOpen", value
+                        self.device_info.sn, "cfgHvAcOutOpen", value
                     ),
                     enableValue=2,
                 ),
                 EnabledEntity(
                     client,
                     self,
-                    "pd.carState",
+                    "flowInfo12v",
                     const.DC_ENABLED,
                     lambda value: DeltaPro3SetMessage(
                         self.device_info.sn, "cfgDc12vOutOpen", value


### PR DESCRIPTION
## Summary
- align Delta3Plus AC/DC switch fields with DeltaPro3

## Testing
- `python -m py_compile custom_components/ecoflow_cloud/devices/internal/delta3_plus.py`

------
https://chatgpt.com/codex/tasks/task_e_68889ae0f3d8832fb5769cbe06a76fe1