### PR TITLE
Fix Delta 3 Plus AC switch

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta3_plus.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta3_plus.py
@@ -16,11 +16,18 @@ class Delta3Plus(Delta3):
                 EnabledEntity(
                     client,
                     self,
-                    "flowInfoAcHvOut",
+                    "mppt.cfgAcEnabled",
                     const.AC_ENABLED,
-                    lambda value: DeltaPro3SetMessage(
-                        self.device_info.sn, "cfgHvAcOutOpen", value
-                    ),
+                    lambda value: {
+                        "moduleType": 5,
+                        "operateType": "acOutCfg",
+                        "params": {
+                            "enabled": value,
+                            "out_voltage": -1,
+                            "out_freq": 255,
+                            "xboost": 255,
+                        },
+                    },
                     enableValue=2,
                 ),
                 EnabledEntity(


### PR DESCRIPTION
## Summary
- fix Delta 3 Plus AC switch logic

## Testing
- `python -m hassfest` *(fails: No module named hassfest)*

------
https://chatgpt.com/codex/tasks/task_e_68889e0cded0832f91145c2515354349