### PR TITLE
Fix Delta 3 Plus AC enable handling

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta3_plus.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta3_plus.py
@@ -16,18 +16,11 @@ class Delta3Plus(Delta3):
                 EnabledEntity(
                     client,
                     self,
-                    "mppt.cfgAcEnabled",
+                    "flowInfoAcOut",
                     const.AC_ENABLED,
-                    lambda value: {
-                        "moduleType": 5,
-                        "operateType": "acOutCfg",
-                        "params": {
-                            "enabled": value,
-                            "out_voltage": -1,
-                            "out_freq": 255,
-                            "xboost": 255,
-                        },
-                    },
+                    lambda value: DeltaPro3SetMessage(
+                        self.device_info.sn, "cfgAcOutOpen", value
+                    ),
                     enableValue=2,
                 ),
                 EnabledEntity(


### PR DESCRIPTION
## Summary
- correct AC enable message for Delta 3 Plus

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6888a495a14c832f9a85f533f4df1801