### PR TITLE
Fix Delta3 Plus DC switch status

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/delta3_plus.py
+++ b/custom_components/ecoflow_cloud/devices/internal/delta3_plus.py
@@ -38,7 +38,7 @@ class Delta3Plus(Delta3):
                 EnabledEntity(
                     client,
                     self,
-                    "flowInfo12v",
+                    "cfgDc12vOutOpen",
                     const.DC_ENABLED,
                     lambda value: DeltaPro3SetMessage(
                         self.device_info.sn, "cfgDc12vOutOpen", value

--- a/docs/devices/Delta_3_Plus-Public.md
+++ b/docs/devices/Delta_3_Plus-Public.md
@@ -90,7 +90,7 @@ message Delta3PlusHeartbeat {
 - X-Boost Enabled
 - AC Enabled
 - AC Always On
-- DC Enabled
+- DC Enabled (`cfgDc12vOutOpen`)
 - USB Enabled
 - Beeper Enabled
 - Charging Pause


### PR DESCRIPTION
## Summary
- read DC switch state from `cfgDc12vOutOpen`
- document DC switch property for Delta 3 Plus

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_6888ce4c6424832fae9177b1bb6de2b6