### PR TITLE
Improve unsupported packet logging

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/powerstream.py
+++ b/custom_components/ecoflow_cloud/devices/internal/powerstream.py
@@ -375,9 +375,11 @@ class PowerStream(PrivateAPIProtoDeviceMixin, BaseDevice):
                     command = Command(command_desc)
                 except ValueError:
                     _LOGGER.info(
-                        "Unsupported EcoPacket cmd_func %u, cmd_id %u",
+                        "Unsupported EcoPacket cmd_func %u, cmd_id %u, pdata %s, message %s",
                         command_desc.func,
                         command_desc.id,
+                        message.pdata.hex(),
+                        message,
                     )
                     continue
 

--- a/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
+++ b/custom_components/ecoflow_cloud/devices/internal/stream_ac.py
@@ -372,7 +372,12 @@ class StreamAC(BaseDevice):
                 if (
                     packet.msg.cmd_id < 0
                 ):  # packet.msg.cmd_id != 21 and packet.msg.cmd_id != 22 and packet.msg.cmd_id != 50:
-                    _LOGGER.info("Unsupported EcoPacket cmd id %u", packet.msg.cmd_id)
+                    _LOGGER.info(
+                        "Unsupported EcoPacket cmd id %u, pdata %s, message %s",
+                        packet.msg.cmd_id,
+                        packet.msg.pdata.hex() if hasattr(packet.msg, "pdata") else "",
+                        packet.msg,
+                    )
 
                 else:
                     _LOGGER.debug('new payload "%s"', str(packet.msg.pdata.hex()))


### PR DESCRIPTION
## Summary
- log raw packet info when unknown command is received

## Testing
- `python -m py_compile custom_components/ecoflow_cloud/devices/internal/powerstream.py custom_components/ecoflow_cloud/devices/internal/stream_ac.py`

------
https://chatgpt.com/codex/tasks/task_e_6889edab0304832fbc7a1aa3fa2edcc8