### PR TITLE
Fix proto import path

### DIFF
--- a/custom_components/ecoflow_cloud/_preload_proto.py
+++ b/custom_components/ecoflow_cloud/_preload_proto.py
@@ -1,3 +1,19 @@
+"""Preload protocol buffer modules and set up package aliases."""
+
+from importlib import import_module
+import sys
+
+# The generated protobuf modules expect the package ``model.protos`` to be
+# importable. When Home Assistant loads this integration as a custom component,
+# the Python path does not include this subpackage.  To keep the generated code
+# unchanged, expose the package here before importing any of the ``*_pb2``
+# modules.
+_model_pkg = import_module(".devices.internal.proto.model", __package__)
+sys.modules.setdefault("model", _model_pkg)
+sys.modules.setdefault(
+    "model.protos", import_module(".devices.internal.proto.model.protos", __package__)
+)
+
 from .devices.internal.proto import (  # noqa: F401
     ecopacket_pb2,  # noqa: F401 # pyright: ignore[reportUnusedImport]
     platform_pb2,  # noqa: F401 # pyright: ignore[reportUnusedImport]


### PR DESCRIPTION
## Summary
- expose `model.protos` package before loading protobuf modules

## Testing
- `python -m compileall -q custom_components/ecoflow_cloud`

------
https://chatgpt.com/codex/tasks/task_e_688a114758cc832f99f4f1a4c378d387