### PR TITLE
Fix protocol mappings for PowerStream

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/powerstream.py
+++ b/custom_components/ecoflow_cloud/devices/internal/powerstream.py
@@ -49,6 +49,7 @@ from google.protobuf.message import Message as ProtoMessageRaw
 from ...switch import EnabledEntity
 from ..internal.proto import platform_pb2 as platform
 from ..internal.proto import powerstream_pb2 as powerstream
+from ..internal.proto import wn511_socket_sys_pb2 as socket_sys
 from ..internal.proto import AddressId, Command, ProtoMessage
 from .proto import PrivateAPIProtoDeviceMixin
 from .proto.support.const import WatthType, get_expected_payload_type
@@ -276,7 +277,7 @@ class PowerStream(PrivateAPIProtoDeviceMixin, BaseDevice):
                 lambda value: build_command(
                     device_sn=self.device_info.sn,
                     command=Command.WN511_SET_SUPPLY_PRIORITY_PACK,
-                    payload=powerstream.SupplyPriorityPack(supply_priority=value),
+                    payload=socket_sys.include_plug(include_plug=value),
                 ),
             ),
         ]
@@ -294,7 +295,7 @@ class PowerStream(PrivateAPIProtoDeviceMixin, BaseDevice):
                 lambda value: build_command(
                     device_sn=self.device_info.sn,
                     command=Command.WN511_SET_BAT_LOWER_PACK,
-                    payload=powerstream.BatLowerPack(lower_limit=value),
+                    payload=socket_sys.bat_lower_pack(lower_limit=value),
                 ),
             ),
             MaxBatteryLevelEntity(
@@ -307,7 +308,7 @@ class PowerStream(PrivateAPIProtoDeviceMixin, BaseDevice):
                 lambda value: build_command(
                     device_sn=self.device_info.sn,
                     command=Command.WN511_SET_BAT_UPPER_PACK,
-                    payload=powerstream.BatUpperPack(upper_limit=value),
+                    payload=socket_sys.bat_upper_pack(upper_limit=value),
                 ),
             ),
             BrightnessLevelEntity(
@@ -320,7 +321,7 @@ class PowerStream(PrivateAPIProtoDeviceMixin, BaseDevice):
                 lambda value: build_command(
                     device_sn=self.device_info.sn,
                     command=Command.WN511_SET_BRIGHTNESS_PACK,
-                    payload=powerstream.BrightnessPack(brightness=value),
+                    payload=socket_sys.brightness_pack(brightness=value),
                 ),
             ),
             DeciChargingPowerEntity(
@@ -333,7 +334,7 @@ class PowerStream(PrivateAPIProtoDeviceMixin, BaseDevice):
                 lambda value: build_command(
                     device_sn=self.device_info.sn,
                     command=Command.WN511_SET_PERMANENT_WATTS_PACK,
-                    payload=powerstream.PermanentWattsPack(permanent_watts=value),
+                    payload=socket_sys.permanent_watts_pack(permanent_watts=value),
                 ),
             ),
         ]

--- a/custom_components/ecoflow_cloud/devices/internal/proto/support/const.py
+++ b/custom_components/ecoflow_cloud/devices/internal/proto/support/const.py
@@ -4,6 +4,7 @@ from typing import NamedTuple, cast
 from google.protobuf.message import Message as ProtoMessageRaw
 
 from .. import platform_pb2 as platform
+from .. import wn511_socket_sys_pb2 as socket_sys
 
 
 # https://github.com/tomvd/local-powerstream/issues/4#issuecomment-2781354316
@@ -83,11 +84,11 @@ def get_expected_payload_type(cmd: Command) -> type[ProtoMessageRaw]:
                 dict[Command, type[ProtoMessageRaw]],
                 {
                     Command.PRIVATE_API_POWERSTREAM_HEARTBEAT: powerstream.InverterHeartbeat,
-                    Command.WN511_SET_PERMANENT_WATTS_PACK: powerstream.PermanentWattsPack,
-                    Command.WN511_SET_SUPPLY_PRIORITY_PACK: powerstream.SupplyPriorityPack,
-                    Command.WN511_SET_BAT_LOWER_PACK: powerstream.BatLowerPack,
-                    Command.WN511_SET_BAT_UPPER_PACK: powerstream.BatUpperPack,
-                    Command.WN511_SET_BRIGHTNESS_PACK: powerstream.BrightnessPack,
+                    Command.WN511_SET_PERMANENT_WATTS_PACK: socket_sys.permanent_watts_pack,
+                    Command.WN511_SET_SUPPLY_PRIORITY_PACK: socket_sys.include_plug,
+                    Command.WN511_SET_BAT_LOWER_PACK: socket_sys.bat_lower_pack,
+                    Command.WN511_SET_BAT_UPPER_PACK: socket_sys.bat_upper_pack,
+                    Command.WN511_SET_BRIGHTNESS_PACK: socket_sys.brightness_pack,
                     Command.PRIVATE_API_POWERSTREAM_SET_FEED_PROTECT: powerstream.PrivateAPIGenericSetValue,
                     Command.PRIVATE_API_PLATFORM_WATTH: platform.BatchEnergyTotalReport,
                 },


### PR DESCRIPTION
## Summary
- update proto const mappings to use the wn511 socket definitions
- adjust PowerStream to build commands with the correct protobuf messages

## Testing
- `python -m compileall -q custom_components/ecoflow_cloud/devices/internal/proto/support/const.py custom_components/ecoflow_cloud/devices/internal/powerstream.py`

------
https://chatgpt.com/codex/tasks/task_e_688a1727ff30832fb9292a628bfcfde2