### PR TITLE
Fix proto preload dependency

### DIFF
--- a/custom_components/ecoflow_cloud/_preload_proto.py
+++ b/custom_components/ecoflow_cloud/_preload_proto.py
@@ -14,6 +14,9 @@ sys.modules.setdefault(
     "model.protos", import_module(".devices.internal.proto.model.protos", __package__)
 )
 
+from .devices.internal.proto.model.protos import (  # noqa: F401
+    options_pb2,  # noqa: F401 # pyright: ignore[reportUnusedImport]
+)
 from .devices.internal.proto import (  # noqa: F401
     ecopacket_pb2,  # noqa: F401 # pyright: ignore[reportUnusedImport]
     platform_pb2,  # noqa: F401 # pyright: ignore[reportUnusedImport]


### PR DESCRIPTION
## Summary
- make sure proto dependencies are loaded early

## Testing
- `python -m compileall -q custom_components/ecoflow_cloud/_preload_proto.py`

------
https://chatgpt.com/codex/tasks/task_e_688a1bef0e08832fa0141903db1e84db