### PR TITLE
Fix feed protect message mapping

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/powerstream.py
+++ b/custom_components/ecoflow_cloud/devices/internal/powerstream.py
@@ -258,7 +258,7 @@ class PowerStream(PrivateAPIProtoDeviceMixin, BaseDevice):
                 lambda value: build_command(
                     device_sn=self.device_info.sn,
                     command=Command.PRIVATE_API_POWERSTREAM_SET_FEED_PROTECT,
-                    payload=powerstream.PrivateAPIGenericSetValue(value=value),
+                    payload=powerstream.SetValue(value=value),
                 ),
                 enabled=True,
                 enableValue=1,

--- a/custom_components/ecoflow_cloud/devices/internal/proto/support/const.py
+++ b/custom_components/ecoflow_cloud/devices/internal/proto/support/const.py
@@ -89,7 +89,7 @@ def get_expected_payload_type(cmd: Command) -> type[ProtoMessageRaw]:
                     Command.WN511_SET_BAT_LOWER_PACK: socket_sys.bat_lower_pack,
                     Command.WN511_SET_BAT_UPPER_PACK: socket_sys.bat_upper_pack,
                     Command.WN511_SET_BRIGHTNESS_PACK: socket_sys.brightness_pack,
-                    Command.PRIVATE_API_POWERSTREAM_SET_FEED_PROTECT: powerstream.PrivateAPIGenericSetValue,
+                    Command.PRIVATE_API_POWERSTREAM_SET_FEED_PROTECT: powerstream.SetValue,
                     Command.PRIVATE_API_PLATFORM_WATTH: platform.BatchEnergyTotalReport,
                 },
             )


### PR DESCRIPTION
## Summary
- use SetValue protobuf message for feed-protect command
- update mapping for expected payload type

## Testing
- `python -m py_compile custom_components/ecoflow_cloud/devices/internal/powerstream.py custom_components/ecoflow_cloud/devices/internal/proto/support/const.py`

------
https://chatgpt.com/codex/tasks/task_e_688a28c04394832fbbd936ad09449759