### PR TITLE
Add PowerStream command 136

### DIFF
--- a/custom_components/ecoflow_cloud/devices/internal/proto/support/const.py
+++ b/custom_components/ecoflow_cloud/devices/internal/proto/support/const.py
@@ -52,6 +52,7 @@ class Command(enum.Enum):
     WN511_SET_BAT_LOWER_PACK = CommandFuncAndId(func=CommandFunc.POWERSTREAM, id=132)
     WN511_SET_BAT_UPPER_PACK = CommandFuncAndId(func=CommandFunc.POWERSTREAM, id=133)
     WN511_SET_BRIGHTNESS_PACK = CommandFuncAndId(func=CommandFunc.POWERSTREAM, id=135)
+    WN511_SET_VALUE_PACK = CommandFuncAndId(func=CommandFunc.POWERSTREAM, id=136)
 
     PRIVATE_API_POWERSTREAM_SET_FEED_PROTECT = CommandFuncAndId(
         func=CommandFunc.POWERSTREAM, id=143
@@ -89,6 +90,7 @@ def get_expected_payload_type(cmd: Command) -> type[ProtoMessageRaw]:
                     Command.WN511_SET_BAT_LOWER_PACK: socket_sys.bat_lower_pack,
                     Command.WN511_SET_BAT_UPPER_PACK: socket_sys.bat_upper_pack,
                     Command.WN511_SET_BRIGHTNESS_PACK: socket_sys.brightness_pack,
+                    Command.WN511_SET_VALUE_PACK: powerstream.SetValue,
                     Command.PRIVATE_API_POWERSTREAM_SET_FEED_PROTECT: powerstream.SetValue,
                     Command.PRIVATE_API_PLATFORM_WATTH: platform.BatchEnergyTotalReport,
                 },

--- a/custom_components/ecoflow_cloud/proto_decode.py
+++ b/custom_components/ecoflow_cloud/proto_decode.py
@@ -87,6 +87,20 @@ def decode_ecopacket(raw_data: bytes) -> Dict[str, Any] | None:
                 )
             except Exception:
                 result["params"]["raw_payload"] = payload.hex()
+        elif (
+            message.cmd_func == CommandFunc.POWERSTREAM
+            and message.cmd_id == Command.WN511_SET_VALUE_PACK.id
+        ):
+            set_value = powerstream_pb2.SetValue()
+            try:
+                set_value.ParseFromString(payload)
+                data = MessageToDict(set_value, preserving_proto_field_name=True)
+                _log_proto("SetValue136", data)
+                result["params"].update(
+                    MessageToDict(set_value, preserving_proto_field_name=False)
+                )
+            except Exception:
+                result["params"]["raw_payload"] = payload.hex()
         elif message.cmd_func == 254 and message.cmd_id == 21:
             display = deltapro3_pb2.DisplayPropertyUpload()
             try:


### PR DESCRIPTION
## Summary
- support cmd 136 in constants
- parse SetValue payloads for POWERSTREAM command 136

## Testing
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_688a325c33e4832fb88604dd20ecbc69