### PR TITLE
Add support for PowerStream HEARTBEAT2

### DIFF
--- a/README.md
+++ b/README.md
@@ -881,7 +881,7 @@ This repository is a fork of the original project by tolwi — I really apprecia
 
 </p></details>
 
-<details><summary> POWERSTREAM <i>(sensors: 63, switches: 1, sliders: 4, selects: 1)</i> </summary>
+<details><summary> POWERSTREAM <i>(sensors: 68, switches: 1, sliders: 4, selects: 1)</i> </summary>
 <p>
 
 *Sensors*
@@ -936,6 +936,11 @@ This repository is a fork of the original project by tolwi — I really apprecia
 - Other Loads
 - Smart Plug Loads
 - Rated Power
+- Base Load
+- Smart Plug Watts +
+- Grid Watts
+- Smart Plug Watts -
+- WiFi RSSI
 - Lower Battery Limit  _(disabled)_
 - Upper Battery Limit  _(disabled)_
 - Wireless Error Code  _(disabled)_
@@ -1827,7 +1832,7 @@ This repository is a fork of the original project by tolwi — I really apprecia
 
 </p></details>
 
-<details><summary> PowerStream (API) <i>(sensors: 58, switches: 0, sliders: 4, selects: 1)</i> </summary>
+<details><summary> PowerStream (API) <i>(sensors: 63, switches: 0, sliders: 4, selects: 1)</i> </summary>
 <p>
 
 *Sensors*
@@ -1882,6 +1887,11 @@ This repository is a fork of the original project by tolwi — I really apprecia
 - Other Loads
 - Smart Plug Loads
 - Rated Power
+- Base Load
+- Smart Plug Watts +
+- Grid Watts
+- Smart Plug Watts -
+- WiFi RSSI
 - Lower Battery Limit  _(disabled)_
 - Upper Battery Limit  _(disabled)_
 - Wireless Error Code  _(disabled)_

--- a/custom_components/ecoflow_cloud/devices/internal/powerstream.py
+++ b/custom_components/ecoflow_cloud/devices/internal/powerstream.py
@@ -33,6 +33,7 @@ from ...sensor import (
     DecivoltSensorEntity,
     DeciwattsSensorEntity,
     InWattsSolarSensorEntity,
+    SignalStrengthSensorEntity,
     LevelSensorEntity,
     MilliampSensorEntity,
     MiscSensorEntity,
@@ -191,6 +192,11 @@ class PowerStream(PrivateAPIProtoDeviceMixin, BaseDevice):
                 client, self, "20_1.dynamicWatts", "Smart Plug Loads"
             ),
             DeciwattsSensorEntity(client, self, "20_1.ratedPower", "Rated Power"),
+            DeciwattsSensorEntity(client, self, "20_4.h2BaseLoad", "Base Load"),
+            DeciwattsSensorEntity(client, self, "20_4.h2PowerPlugsPos", "Smart Plug Watts +"),
+            DeciwattsSensorEntity(client, self, "20_4.h2GridWatt45", "Grid Watts"),
+            DeciwattsSensorEntity(client, self, "20_4.h2PowerPlugsNeg", "Smart Plug Watts -"),
+            SignalStrengthSensorEntity(client, self, "20_4.h2WifiRssi", "WiFi RSSI"),
             MiscSensorEntity(
                 client, self, "20_1.lowerLimit", "Lower Battery Limit", False
             ),
@@ -385,7 +391,10 @@ class PowerStream(PrivateAPIProtoDeviceMixin, BaseDevice):
                     continue
 
                 params = cast(JSONDict, res.setdefault("params", {}))
-                if command in {Command.PRIVATE_API_POWERSTREAM_HEARTBEAT}:
+                if command in {
+                    Command.PRIVATE_API_POWERSTREAM_HEARTBEAT,
+                    Command.PRIVATE_API_POWERSTREAM_HEARTBEAT2,
+                }:
                     payload = get_expected_payload_type(command)()
                     _ = payload.ParseFromString(message.pdata)
                     params.update(

--- a/custom_components/ecoflow_cloud/devices/internal/proto/support/const.py
+++ b/custom_components/ecoflow_cloud/devices/internal/proto/support/const.py
@@ -43,6 +43,10 @@ class Command(enum.Enum):
         func=CommandFunc.POWERSTREAM, id=1
     )
 
+    PRIVATE_API_POWERSTREAM_HEARTBEAT2 = CommandFuncAndId(
+        func=CommandFunc.POWERSTREAM, id=4
+    )
+
     WN511_SET_PERMANENT_WATTS_PACK = CommandFuncAndId(
         func=CommandFunc.POWERSTREAM, id=129
     )
@@ -85,6 +89,7 @@ def get_expected_payload_type(cmd: Command) -> type[ProtoMessageRaw]:
                 dict[Command, type[ProtoMessageRaw]],
                 {
                     Command.PRIVATE_API_POWERSTREAM_HEARTBEAT: powerstream.InverterHeartbeat,
+                    Command.PRIVATE_API_POWERSTREAM_HEARTBEAT2: powerstream.InverterHeartbeat2,
                     Command.WN511_SET_PERMANENT_WATTS_PACK: socket_sys.permanent_watts_pack,
                     Command.WN511_SET_SUPPLY_PRIORITY_PACK: socket_sys.include_plug,
                     Command.WN511_SET_BAT_LOWER_PACK: socket_sys.bat_lower_pack,

--- a/custom_components/ecoflow_cloud/devices/internal/proto/support/device.py
+++ b/custom_components/ecoflow_cloud/devices/internal/proto/support/device.py
@@ -13,7 +13,11 @@ class PrivateAPIProtoDeviceMixin(object):
             "cmdFunc" in message
             and "cmdId" in message
             and message["cmdFunc"] == Command.PRIVATE_API_POWERSTREAM_HEARTBEAT.func
-            and message["cmdId"] == Command.PRIVATE_API_POWERSTREAM_HEARTBEAT.id
+            and message["cmdId"]
+            in {
+                Command.PRIVATE_API_POWERSTREAM_HEARTBEAT.id,
+                Command.PRIVATE_API_POWERSTREAM_HEARTBEAT2.id,
+            }
         ):
             return {"params": message["params"], "time": dt.utcnow()}
         raise ValueError("not a quota message")

--- a/custom_components/ecoflow_cloud/sensor.py
+++ b/custom_components/ecoflow_cloud/sensor.py
@@ -378,6 +378,13 @@ class DeciampSensorEntity(BaseSensorEntity):
         return super()._update_value(int(val) / 10)
 
 
+class SignalStrengthSensorEntity(BaseSensorEntity):
+    _attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
+    _attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+
 class WattsSensorEntity(BaseSensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_device_class = SensorDeviceClass.POWER

--- a/docs/devices/POWERSTREAM.md
+++ b/docs/devices/POWERSTREAM.md
@@ -1,6 +1,7 @@
 ## POWERSTREAM
 
 *Sensors*
+- Extended heartbeat metrics (`20_4.*`) such as base load and grid wattage
 - ESP Temperature (`20_1.espTempsensor`)
 - Solar 1 Watts (`20_1.pv1InputWatts`)
 - Solar 1 Input Potential (`20_1.pv1InputVolt`)
@@ -52,6 +53,11 @@
 - Other Loads (`20_1.permanentWatts`)
 - Smart Plug Loads (`20_1.dynamicWatts`)
 - Rated Power (`20_1.ratedPower`)
+- Base Load (`20_4.h2BaseLoad`)
+- Smart Plug Watts + (`20_4.h2PowerPlugsPos`)
+- Grid Watts (`20_4.h2GridWatt45`)
+- Smart Plug Watts - (`20_4.h2PowerPlugsNeg`)
+- WiFi RSSI (`20_4.h2WifiRssi`)
 - Lower Battery Limit (`20_1.lowerLimit`)   _(disabled)_
 - Upper Battery Limit (`20_1.upperLimit`)   _(disabled)_
 - Wireless Error Code (`20_1.wirelessErrCode`)   _(disabled)_

--- a/docs/devices/PowerStream-Public.md
+++ b/docs/devices/PowerStream-Public.md
@@ -52,6 +52,11 @@
 - Other Loads (`20_1.permanentWatts`)
 - Smart Plug Loads (`20_1.dynamicWatts`)
 - Rated Power (`20_1.ratedPower`)
+- Base Load (`20_4.h2BaseLoad`)
+- Smart Plug Watts + (`20_4.h2PowerPlugsPos`)
+- Grid Watts (`20_4.h2GridWatt45`)
+- Smart Plug Watts - (`20_4.h2PowerPlugsNeg`)
+- WiFi RSSI (`20_4.h2WifiRssi`)
 - Lower Battery Limit (`20_1.lowerLimit`)   _(disabled)_
 - Upper Battery Limit (`20_1.upperLimit`)   _(disabled)_
 - Wireless Error Code (`20_1.wirelessErrCode`)   _(disabled)_

--- a/docs/summary.md
+++ b/docs/summary.md
@@ -865,7 +865,7 @@
 
 </p></details>
 
-<details><summary> POWERSTREAM <i>(sensors: 63, switches: 1, sliders: 4, selects: 1)</i> </summary>
+<details><summary> POWERSTREAM <i>(sensors: 68, switches: 1, sliders: 4, selects: 1)</i> </summary>
 <p>
 
 *Sensors*
@@ -920,6 +920,11 @@
 - Other Loads
 - Smart Plug Loads
 - Rated Power
+- Base Load
+- Smart Plug Watts +
+- Grid Watts
+- Smart Plug Watts -
+- WiFi RSSI
 - Lower Battery Limit  _(disabled)_
 - Upper Battery Limit  _(disabled)_
 - Wireless Error Code  _(disabled)_
@@ -1811,7 +1816,7 @@
 
 </p></details>
 
-<details><summary> PowerStream (API) <i>(sensors: 58, switches: 0, sliders: 4, selects: 1)</i> </summary>
+<details><summary> PowerStream (API) <i>(sensors: 63, switches: 0, sliders: 4, selects: 1)</i> </summary>
 <p>
 
 *Sensors*
@@ -1866,6 +1871,11 @@
 - Other Loads
 - Smart Plug Loads
 - Rated Power
+- Base Load
+- Smart Plug Watts +
+- Grid Watts
+- Smart Plug Watts -
+- WiFi RSSI
 - Lower Battery Limit  _(disabled)_
 - Upper Battery Limit  _(disabled)_
 - Wireless Error Code  _(disabled)_


### PR DESCRIPTION
## Summary
- handle cmd_id 4 (HEARTBEAT2) packets in PowerStream
- expose HEARTBEAT2 details in proto constants
- allow quota extraction from both heartbeat types
- note extended heartbeat metrics in documentation
- show new metrics like base load, grid watts, and WiFi RSSI as sensors

## Testing
- `python -m compileall -q custom_components/ecoflow_cloud/sensor.py custom_components/ecoflow_cloud/devices/internal/powerstream.py custom_components/ecoflow_cloud/devices/internal/proto/support/const.py custom_components/ecoflow_cloud/devices/internal/proto/support/device.py`

------
https://chatgpt.com/codex/tasks/task_e_688a75012a2c832f819fee3a0856e205