### PR TITLE
Handle unknown command types in ProtoMessage

### DIFF
--- a/custom_components/ecoflow_cloud_ai/devices/internal/proto/support/message.py
+++ b/custom_components/ecoflow_cloud_ai/devices/internal/proto/support/message.py
@@ -38,15 +38,15 @@ class ProtoMessage(PrivateAPIMessageProtocol, Message):
         self.device_sn = device_sn
 
     def _verify_command_and_payload(self) -> None:
-        if (
-            self.command is not None
-            and self.payload is not None
-            and not isinstance(self.payload, get_expected_payload_type(self.command))
-        ):
+        if self.command is None or self.payload is None:
+            return
+
+        expected_type = _expected_payload_types.get(self.command)
+        if expected_type is not None and not isinstance(self.payload, expected_type):
             _LOGGER.warning(
                 'Command "%s": allowed payload types %s, got %s',
                 self.command.name,
-                get_expected_payload_type(self.command),
+                expected_type,
                 type(self.payload),
             )
 


### PR DESCRIPTION
## Summary
- prevent `_verify_command_and_payload` from throwing a KeyError when a command type doesn't have an expected payload type

## Testing
- `python3 -m py_compile custom_components/ecoflow_cloud_ai/devices/internal/proto/support/message.py`
- `python3 -m homeassistant.scripts.hassfest 2>&1 | head -n 20` *(fails: No module named homeassistant.scripts.hassfest)*

------
https://chatgpt.com/codex/tasks/task_e_688b3e2f3ba4832f884850c05d8fb329