### PR TITLE
Fix NameError in ProtoMessage

### DIFF
--- a/custom_components/ecoflow_cloud_ai/devices/internal/proto/support/message.py
+++ b/custom_components/ecoflow_cloud_ai/devices/internal/proto/support/message.py
@@ -41,7 +41,11 @@ class ProtoMessage(PrivateAPIMessageProtocol, Message):
         if self.command is None or self.payload is None:
             return
 
-        expected_type = _expected_payload_types.get(self.command)
+        try:
+            expected_type = get_expected_payload_type(self.command)
+        except KeyError:
+            expected_type = None
+
         if expected_type is not None and not isinstance(self.payload, expected_type):
             _LOGGER.warning(
                 'Command "%s": allowed payload types %s, got %s',


### PR DESCRIPTION
## Summary
- ensure `_verify_command_and_payload` loads expected type via helper function

## Testing
- `python -m compileall -q custom_components/ecoflow_cloud_ai/devices/internal/proto/support/message.py`

------
https://chatgpt.com/codex/tasks/task_e_688b4897bed8832f92c17a1fdc2a3210