### PR TITLE
Fix unique IDs for energy sensors

### DIFF
--- a/custom_components/ecoflow_cloud_ai/sensor.py
+++ b/custom_components/ecoflow_cloud_ai/sensor.py
@@ -405,6 +405,25 @@ class EnergySensorEntity(BaseSensorEntity):
     _attr_native_unit_of_measurement = UnitOfEnergy.WATT_HOUR
     _attr_state_class = SensorStateClass.TOTAL_INCREASING
 
+    def __init__(
+        self,
+        client: EcoflowApiClient,
+        device: BaseDevice,
+        mqtt_key: str,
+        title: str,
+        enabled: bool = True,
+        auto_enable: bool = False,
+    ) -> None:
+        # Append a suffix to ensure unique IDs for sensors sharing the same key
+        super().__init__(
+            client,
+            device,
+            f"{mqtt_key}.energy",
+            title,
+            enabled,
+            auto_enable,
+        )
+
     def _update_value(self, val: Any) -> bool:
         ival = int(val)
         if ival > 0:


### PR DESCRIPTION
## Summary
- ensure energy sensors generate a unique ID different from the power sensor using the same key

## Testing
- `python -m compileall -q custom_components/ecoflow_cloud_ai`


------
https://chatgpt.com/codex/tasks/task_e_688b81d84a28832f8d6fd0b17d60e92e