### PR TITLE
Fix PowerStream energy sensor data lookup

### DIFF
--- a/custom_components/ecoflow_cloud_ai/__init__.py
+++ b/custom_components/ecoflow_cloud_ai/__init__.py
@@ -9,6 +9,7 @@ from . import _preload_proto  # noqa: F401 # pyright: ignore[reportUnusedImport]
 from .device_data import DeviceData, DeviceOptions
 
 _LOGGER = logging.getLogger(__name__)
+_LOGGER.setLevel(logging.DEBUG)
 
 ECOFLOW_DOMAIN = "ecoflow_cloud_ai"
 CONFIG_VERSION = 11

--- a/custom_components/ecoflow_cloud_ai/sensor.py
+++ b/custom_components/ecoflow_cloud_ai/sensor.py
@@ -414,14 +414,11 @@ class EnergySensorEntity(BaseSensorEntity):
         enabled: bool = True,
         auto_enable: bool = False,
     ) -> None:
-        # Append a suffix to ensure unique IDs for sensors sharing the same key
-        super().__init__(
-            client,
-            device,
-            f"{mqtt_key}.energy",
-            title,
-            enabled,
-            auto_enable,
+        # Use mqtt_key for data lookups but append a suffix for the unique_id to
+        # avoid collisions with power sensors using the same key.
+        super().__init__(client, device, mqtt_key, title, enabled, auto_enable)
+        self._attr_unique_id = self._gen_unique_id(
+            self._device.device_data.sn, f"{mqtt_key}.energy"
         )
 
     def _update_value(self, val: Any) -> bool:

--- a/tests/test_energy_sensor.py
+++ b/tests/test_energy_sensor.py
@@ -1,0 +1,44 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from custom_components.ecoflow_cloud_ai.sensor import EnergySensorEntity
+from custom_components.ecoflow_cloud_ai.devices import EcoflowDeviceInfo
+from custom_components.ecoflow_cloud_ai.device_data import DeviceData, DeviceOptions
+
+class DummyDevice:
+    def __init__(self):
+        self.device_info = EcoflowDeviceInfo(
+            public_api=True,
+            sn="sn123",
+            name="dev",
+            device_type="type",
+            status=0,
+            data_topic="data",
+            set_topic="set",
+            set_reply_topic="set_reply",
+            get_topic=None,
+            get_reply_topic=None,
+            status_topic=None,
+        )
+        self.device_data = DeviceData(
+            sn="sn123",
+            name="dev",
+            device_type="type",
+            options=DeviceOptions(refresh_period=10, power_step=1, diagnostic_mode=False),
+            display_name=None,
+            parent=None,
+        )
+        self.coordinator = None
+
+    def flat_json(self):
+        return True
+
+
+def test_energy_sensor_unique_id_and_key():
+    device = DummyDevice()
+    sensor = EnergySensorEntity(object(), device, "254_32.watthPv1", "PV1 Today Energy Total")
+    assert sensor.mqtt_key == "254_32.watthPv1"
+    assert sensor.unique_id == "ecoflow-api-sn123-254-32-watthPv1-energy"


### PR DESCRIPTION
## Summary
- use raw MQTT key for PowerStream energy sensors
- add regression test verifying sensor initialization
- enable debug logging by default

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c9eb8037c832fadd74d0c99fea344