### PR TITLE
Fix DeltaPro3 energy sensors

### DIFF
--- a/custom_components/ecoflow_cloud_ai/devices/internal/delta_pro_3.py
+++ b/custom_components/ecoflow_cloud_ai/devices/internal/delta_pro_3.py
@@ -200,11 +200,11 @@ class DeltaPro3(BaseDevice):
             OutProtectedEnergySensorEntity(
                 client, self, "powGetAc", const.DISCHARGE_AC_ENERGY
             ),
-            InProtectedEnergySensorEntity(
-                client, self, "powInSumW", const.TOTAL_IN_ENERGY
+            InEnergySensorEntity(
+                client, self, "powInSumEnergy", const.TOTAL_IN_ENERGY
             ),
-            OutProtectedEnergySensorEntity(
-                client, self, "powOutSumW", const.TOTAL_OUT_ENERGY
+            OutEnergySensorEntity(
+                client, self, "powOutSumEnergy", const.TOTAL_OUT_ENERGY
             ),
             InEnergySensorEntity(client, self, "powInSumEnergy", "Total Input Energy"),
             OutEnergySensorEntity(


### PR DESCRIPTION
## Summary
- read total in/out energy counters on DeltaPro3 from `powInSumEnergy`/`powOutSumEnergy`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cbc30d600832f93f2514b647f9bab