### PR TITLE
Fix PowerStream offline detection

### DIFF
--- a/custom_components/ecoflow_cloud_ai/devices/data_holder.py
+++ b/custom_components/ecoflow_cloud_ai/devices/data_holder.py
@@ -57,9 +57,12 @@ class EcoflowDataHolder:
         self.raw_data = BoundFifoList[dict[str, Any]]()
 
     def last_received_time(self):
-        return max(
-            self.status_time, self.params_time, self.get_reply_time, self.set_reply_time
-        )
+        """Return the timestamp of the last payload received from device.
+
+        Replies to get/set commands are intentionally ignored as those
+        responses may come from the cloud even when the device is offline.
+        """
+        return max(self.status_time, self.params_time)
 
     def add_set_message(self, msg: dict[str, Any]):
         self.set.append(msg)

--- a/tests/test_data_holder.py
+++ b/tests/test_data_holder.py
@@ -1,0 +1,20 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from custom_components.ecoflow_cloud_ai.devices.data_holder import EcoflowDataHolder
+
+
+def test_last_received_time_ignores_replies():
+    def extractor(msg):
+        raise ValueError
+
+    holder = EcoflowDataHolder(extractor)
+    holder.update_data({"params": {"a": 1}})
+    first = holder.last_received_time()
+
+    holder.add_get_reply_message({})
+    holder.add_set_reply_message({})
+
+    assert holder.last_received_time() == first


### PR DESCRIPTION
## Summary
- ignore get/set replies when computing last device data time to avoid false online state
- add regression test for data holder timestamp logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f05adefb4832f84020ec9ad8d1b61